### PR TITLE
[F] add Slider component

### DIFF
--- a/packages/epo-react-lib/package.json
+++ b/packages/epo-react-lib/package.json
@@ -39,6 +39,7 @@
     "flickity": "^3.0.0",
     "react-player": "^2.11.0",
     "react-share": "^4.4.1",
+    "react-slider": "^2.0.4",
     "react-uid": "^2.3.2",
     "styled-components": "^5.3.6"
   },
@@ -66,6 +67,7 @@
     "@types/jest": "^29.0.3",
     "@types/react": "^18.0.17",
     "@types/react-dom": "^18.0.6",
+    "@types/react-slider": "^1.3.1",
     "@types/styled-components": "^5.1.26",
     "@vitejs/plugin-react": "^3.0.1",
     "babel-loader": "^8.2.5",

--- a/packages/epo-react-lib/src/form/HorizontalSlider/HorizontalSlider.stories.tsx
+++ b/packages/epo-react-lib/src/form/HorizontalSlider/HorizontalSlider.stories.tsx
@@ -1,0 +1,158 @@
+import {
+  ComponentMeta,
+  ComponentStory,
+  ComponentStoryObj,
+} from "@storybook/react";
+import { useState } from "react";
+
+import HorizontalSlider from ".";
+import { Container } from "../../index";
+
+const meta: ComponentMeta<typeof HorizontalSlider> = {
+  component: HorizontalSlider,
+  argTypes: {
+    min: {
+      control: "number",
+      description: "The maximum value of the slider.",
+      table: {
+        category: "Slider",
+        type: { summary: "number" },
+        defaultValue: { summary: 0 },
+      },
+    },
+    max: {
+      control: "number",
+      description: "The minimum value of the slider.",
+      table: {
+        category: "Slider",
+        type: { summary: "number" },
+        defaultValue: { summary: 100 },
+      },
+    },
+    step: {
+      control: { type: "number", min: 0 },
+      description:
+        "Value to be added or subtracted on each step the slider makes. Must be greater than zero. max - min should be evenly divisible by the step value.",
+      table: {
+        category: "Slider",
+        type: { summary: "number" },
+        defaultValue: { summary: 1 },
+      },
+    },
+    value: {
+      description:
+        "Determines the initial positions of the thumbs and the number of thumbs. If a number is passed a slider with one thumb will be rendered. If an array is passed each value will determine the position of one thumb. The values in the array must be sorted.",
+      type: { name: "other", required: true, value: "number | number[]" },
+      table: {
+        category: "Slider",
+        type: { summary: "number | number[]" },
+      },
+    },
+    label: {
+      control: "text",
+      type: { name: "string", required: true },
+      description:
+        "Unique label attached to the slider to differentiate it in callbacks.",
+      table: {
+        category: "Labels",
+        type: { summary: "string" },
+      },
+    },
+    minLabel: {
+      control: "text",
+      description:
+        "Text label displayed above the left side `min` value of the slider.",
+      table: {
+        category: "Labels",
+        type: { summary: "string" },
+      },
+    },
+    maxLabel: {
+      control: "text",
+      description:
+        "Text label displayed above the right side `max` value of the slider.",
+      table: {
+        category: "Labels",
+        type: { summary: "string" },
+      },
+    },
+    labelledbyId: {
+      control: "text",
+      description:
+        "`aria-labelledby` for screen-readers to apply to the thumbs. Used when slider rendered with separate label. For ranged values the ID's for `minLabel` and `maxLabel` will be used and `labelledbyId` ignored.",
+      table: {
+        category: "Labels",
+        type: { summary: "string" },
+      },
+    },
+    color: {
+      control: "color",
+      description:
+        "Color that either fills the slider starting from the left for single values, or fills the slider between the two thumbs for ranged values.",
+      table: {
+        category: "Styling",
+        type: { summary: "string" },
+        defaultValue: { summary: "transparent" },
+      },
+    },
+    darkMode: {
+      control: "boolean",
+      description:
+        "Inverts color scheme for visibility against dark backgrounds.",
+      table: {
+        category: "Styling",
+        type: { summary: "boolean" },
+        defaultValue: { summary: false },
+      },
+    },
+    onChangeCallback: {
+      type: { name: "function", required: true },
+      action: "Value changed",
+      description:
+        "Callback to bind to the `onAfterChange` event. Will pass the new value along with the slider's `label`.",
+      table: {
+        category: "Function",
+        type: {
+          summary: "(value: number | readonly number[], label: string) => void",
+        },
+      },
+    },
+  },
+};
+
+export default meta;
+
+const Template: ComponentStory<typeof HorizontalSlider> = ({
+  value: argValue,
+  ...args
+}) => {
+  const [value, setValue] = useState(argValue);
+
+  return (
+    <HorizontalSlider
+      {...args}
+      value={value}
+      onChangeCallback={(value) => setValue(value)}
+    />
+  );
+};
+
+export const Primary: ComponentStoryObj<typeof HorizontalSlider> =
+  Template.bind({});
+
+Primary.args = {
+  value: 50,
+  label: "primaryExample",
+  color: "var(--orange55)",
+};
+
+export const DoubleHandle: ComponentStoryObj<typeof HorizontalSlider> =
+  Template.bind({});
+
+DoubleHandle.args = {
+  ...Primary.args,
+  value: [20, 80],
+  label: "doubleHandleExample",
+  minLabel: "Min",
+  maxLabel: "Max",
+};

--- a/packages/epo-react-lib/src/form/HorizontalSlider/HorizontalSlider.stories.tsx
+++ b/packages/epo-react-lib/src/form/HorizontalSlider/HorizontalSlider.stories.tsx
@@ -88,11 +88,10 @@ const meta: ComponentMeta<typeof HorizontalSlider> = {
     color: {
       control: "color",
       description:
-        "Color that either fills the slider starting from the left for single values, or fills the slider between the two thumbs for ranged values.",
+        "Color that either fills the slider starting from the left for single values, or fills the slider between the two thumbs for ranged values. Also fills the background-color of the slider thumb.\n\nCan also be a CSS variable.",
       table: {
         category: "Styling",
         type: { summary: "string" },
-        defaultValue: { summary: "transparent" },
       },
     },
     darkMode: {
@@ -143,7 +142,6 @@ export const Primary: ComponentStoryObj<typeof HorizontalSlider> =
 Primary.args = {
   value: 50,
   label: "primaryExample",
-  color: "var(--orange55)",
 };
 
 export const DoubleHandle: ComponentStoryObj<typeof HorizontalSlider> =

--- a/packages/epo-react-lib/src/form/HorizontalSlider/HorizontalSlider.test.tsx
+++ b/packages/epo-react-lib/src/form/HorizontalSlider/HorizontalSlider.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import HorizontalSlider from ".";
+
+beforeEach(() => {
+  window.ResizeObserver =
+    window.ResizeObserver ||
+    jest.fn().mockImplementation(() => ({
+      disconnect: jest.fn(),
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+    }));
+});
+
+const min = 10;
+const max = 120;
+const value = 50;
+
+const props = {
+  min,
+  max,
+  value,
+  onChangeCallback: jest.fn(),
+  label: "test-slider",
+};
+
+describe("HorizontalSlider", () => {
+  it("Creates an accessible slider", () => {
+    render(<HorizontalSlider {...props} />);
+
+    const slider = screen.getByRole("slider");
+
+    expect(slider).toBeDefined;
+    expect(slider).toHaveAttribute("aria-valuemin", min.toString());
+    expect(slider).toHaveAttribute("aria-valuenow", value.toString());
+    expect(slider).toHaveAttribute("aria-valuemax", max.toString());
+    expect(slider).toHaveAttribute("aria-orientation", "horizontal");
+  });
+  it("Displays a double handled slider", () => {
+    const values = [20, 80];
+    const minLabel = "MinLabel";
+    const maxLabel = "MaxLabel";
+
+    render(
+      <HorizontalSlider {...{ ...props, value: values, minLabel, maxLabel }} />
+    );
+
+    const left = screen.getByLabelText(minLabel);
+    const right = screen.getByLabelText(maxLabel);
+    expect(left).toHaveAttribute("aria-valuenow", values[0].toString());
+    expect(left).to;
+    expect(right).toHaveAttribute("aria-valuenow", values[1].toString());
+  });
+});

--- a/packages/epo-react-lib/src/form/HorizontalSlider/HorizontalSlider.tsx
+++ b/packages/epo-react-lib/src/form/HorizontalSlider/HorizontalSlider.tsx
@@ -1,0 +1,98 @@
+import { useState, FunctionComponent } from "react";
+import * as Styled from "./styles";
+
+type SliderValue = number | readonly number[];
+
+interface HorizontalSliderProps {
+  min?: number;
+  max?: number;
+  step?: number;
+  value: number | number[];
+  label: string;
+  minLabel?: string;
+  maxLabel?: string;
+  labelledbyId?: string;
+  onChangeCallback: (value: number | number[], label: string) => void;
+  color?: string;
+  darkMode?: boolean;
+}
+
+const HorizontalSlider: FunctionComponent<HorizontalSliderProps> = ({
+  min = 0,
+  max = 100,
+  step = 1,
+  value,
+  onChangeCallback,
+  label,
+  minLabel,
+  maxLabel,
+  labelledbyId,
+  color = "transparent",
+  darkMode = false,
+}) => {
+  const [showThumbLabels, setShowThumbLabels] = useState(false);
+  const hasDoubleHandles = Array.isArray(value) && value.length > 1;
+
+  const handleChange = (value: SliderValue) => {
+    setShowThumbLabels(false);
+    if (onChangeCallback) onChangeCallback(value as number | number[], label);
+  };
+
+  const Track = (props: any, state: { index: number; value: SliderValue }) => {
+    const { index } = state;
+    const hasColor =
+      (hasDoubleHandles && index === 1) || (!hasDoubleHandles && index === 0);
+
+    return <Styled.Track color={hasColor ? color : "transparent"} {...props} />;
+  };
+
+  const Thumb = (
+    props: any,
+    state: { index: number; value: SliderValue; valueNow: number }
+  ) => {
+    const { valueNow } = state;
+
+    return (
+      <Styled.ThumbContainer {...{ ...props }}>
+        <Styled.Thumb />
+        <Styled.ThumbLabel {...{ showThumbLabels, darkMode }}>
+          {valueNow}
+        </Styled.ThumbLabel>
+      </Styled.ThumbContainer>
+    );
+  };
+
+  const minLabelId = `${label}-min-label`;
+  const maxLabelId = `${label}-max-label`;
+
+  return (
+    <Styled.HorizontalSliderContainer>
+      {minLabel || maxLabel ? (
+        <Styled.TrackLabels>
+          <Styled.Label id={minLabelId} {...{ darkMode }}>
+            {minLabel}
+          </Styled.Label>
+          <Styled.Label id={maxLabelId} {...{ darkMode }}>
+            {maxLabel}
+          </Styled.Label>
+        </Styled.TrackLabels>
+      ) : null}
+      <Styled.HorizontalSlider
+        {...{ min, max, step, value, showThumbLabels }}
+        onChange={() => {
+          setShowThumbLabels(true);
+        }}
+        onAfterChange={handleChange}
+        renderTrack={Track}
+        renderThumb={Thumb}
+        ariaLabelledby={
+          hasDoubleHandles ? [minLabelId, maxLabelId] : labelledbyId
+        }
+      />
+    </Styled.HorizontalSliderContainer>
+  );
+};
+
+HorizontalSlider.displayName = "Form.HorizontalSlider";
+
+export default HorizontalSlider;

--- a/packages/epo-react-lib/src/form/HorizontalSlider/HorizontalSlider.tsx
+++ b/packages/epo-react-lib/src/form/HorizontalSlider/HorizontalSlider.tsx
@@ -27,7 +27,7 @@ const HorizontalSlider: FunctionComponent<HorizontalSliderProps> = ({
   minLabel,
   maxLabel,
   labelledbyId,
-  color = "transparent",
+  color,
   darkMode = false,
 }) => {
   const [showThumbLabels, setShowThumbLabels] = useState(false);
@@ -54,7 +54,7 @@ const HorizontalSlider: FunctionComponent<HorizontalSliderProps> = ({
 
     return (
       <Styled.ThumbContainer {...{ ...props }}>
-        <Styled.Thumb />
+        <Styled.Thumb {...{ color }} />
         <Styled.ThumbLabel {...{ showThumbLabels, darkMode }}>
           {valueNow}
         </Styled.ThumbLabel>

--- a/packages/epo-react-lib/src/form/HorizontalSlider/index.ts
+++ b/packages/epo-react-lib/src/form/HorizontalSlider/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./HorizontalSlider";

--- a/packages/epo-react-lib/src/form/HorizontalSlider/styles.ts
+++ b/packages/epo-react-lib/src/form/HorizontalSlider/styles.ts
@@ -1,0 +1,114 @@
+import styled, { css } from "styled-components";
+import ReactSlider from "react-slider";
+
+const sliderHeight = 22;
+const sliderBorder = 6;
+const trackHeight = sliderHeight - sliderBorder * 2;
+const thumbBorder = 4;
+const thumbHeight = 26;
+
+export const HorizontalSliderContainer = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  padding-bottom: 16px;
+`;
+
+export const TrackLabels = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 3px 6px;
+`;
+
+export const Label = styled.div<{ darkMode: boolean }>`
+  box-sizing: border-box;
+  font-size: 14px;
+  font-weight: bold;
+  line-height: 1.6;
+  color: ${({ darkMode }) =>
+    darkMode ? css`var(--white, #fff)` : css`inherit`};
+`;
+
+export const ThumbLabel = styled.span<{
+  showThumbLabels: boolean;
+  darkMode: boolean;
+}>`
+  box-sizing: border-box;
+  position: absolute;
+  top: calc(100% + ${thumbBorder}px);
+  padding: 5px;
+  font-size: 14px;
+  font-weight: normal;
+  text-align: center;
+  line-height: 1.35;
+  border-radius: 5px;
+  opacity: ${({ showThumbLabels }) => (showThumbLabels ? 1 : 0)};
+  transition: opacity 0.4s ease-in-out;
+  user-select: none;
+
+  ${({ darkMode }) =>
+    darkMode
+      ? css`
+          border: 1px solid var(--white);
+          background-color: var(--neutral80);
+          color: var(--white, #fff);
+        `
+      : css`
+          border: 1px solid var(--blue20);
+          background-color: var(--neutral10);
+          color: var(--black, #000);
+        `}
+`;
+
+export const ThumbContainer = styled.div`
+  &:focus,
+  &.active {
+    outline: none;
+  }
+`;
+
+export const Thumb = styled.div`
+  box-sizing: border-box;
+  position: relative;
+  width: ${thumbHeight}px;
+  height: ${thumbHeight}px;
+  color: var(--white, #fff);
+  text-align: center;
+  cursor: grab;
+  background-color: var(--turquoise55);
+  border: ${thumbBorder}px solid var(--neutral10);
+  border-radius: 50%;
+
+  &:focus,
+  &:active,
+  &.active {
+    cursor: grabbing;
+    outline: none;
+
+    ${ThumbLabel} {
+      opacity: 1;
+    }
+  }
+`;
+
+export const Track = styled.div<{ color: string }>`
+  box-sizing: border-box;
+  border-radius: ${trackHeight / 2}px;
+  background-color: ${({ color }) => color};
+  height: ${trackHeight}px;
+`;
+
+export const HorizontalSlider = styled(ReactSlider)`
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  height: ${sliderHeight}px;
+  background-color: var(--neutral10);
+  border: ${sliderBorder}px solid var(--neutral40);
+  border-radius: 20px;
+
+  & + & {
+    margin-top: 43px;
+  }
+`;

--- a/packages/epo-react-lib/src/form/HorizontalSlider/styles.ts
+++ b/packages/epo-react-lib/src/form/HorizontalSlider/styles.ts
@@ -68,7 +68,7 @@ export const ThumbContainer = styled.div`
   }
 `;
 
-export const Thumb = styled.div`
+export const Thumb = styled.div<{ color?: string }>`
   box-sizing: border-box;
   position: relative;
   width: ${thumbHeight}px;
@@ -76,7 +76,7 @@ export const Thumb = styled.div`
   color: var(--white, #fff);
   text-align: center;
   cursor: grab;
-  background-color: var(--turquoise55);
+  background-color: ${({ color = "var(--turquoise55, #009fa1)" }) => color};
   border: ${thumbBorder}px solid var(--neutral10);
   border-radius: 50%;
 
@@ -92,10 +92,10 @@ export const Thumb = styled.div`
   }
 `;
 
-export const Track = styled.div<{ color: string }>`
+export const Track = styled.div<{ color?: string }>`
   box-sizing: border-box;
   border-radius: ${trackHeight / 2}px;
-  background-color: ${({ color }) => color};
+  background-color: ${({ color = "var(--neutral10, #f5f5f5)" }) => color};
   height: ${trackHeight}px;
 `;
 

--- a/packages/epo-react-lib/src/form/Switch/Switch.stories.tsx
+++ b/packages/epo-react-lib/src/form/Switch/Switch.stories.tsx
@@ -1,4 +1,3 @@
-import Icons from "@/svg/icons";
 import { ComponentMeta, ComponentStoryObj } from "@storybook/react";
 
 import Switch from ".";

--- a/packages/epo-react-lib/src/index.ts
+++ b/packages/epo-react-lib/src/index.ts
@@ -28,6 +28,7 @@ export { default as ComplexTable } from "@/content-blocks/ComplexTable";
 export { default as Error } from "@/form/Error";
 export { default as FormButtons } from "@/form/FormButtons";
 export { default as FormField } from "@/form/FormField";
+export { default as HorizontalSlider } from "@/form/HorizontalSlider";
 export { default as Input, Password } from "@/form/Input";
 export { default as Select } from "@/form/Select";
 export { default as Switch } from "@/form/Switch";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1898,24 +1898,24 @@
   resolved "https://registry.yarnpkg.com/@mdx-js/util/-/util-1.6.22.tgz#219dfd89ae5b97a8801f015323ffa4b62f45718b"
   integrity sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==
 
-"@microsoft/api-extractor-model@7.26.1":
-  version "7.26.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.26.1.tgz#6ba65af964a77b130e0122e67902dcb89dd7dbb8"
-  integrity sha512-d/IwUIFDXYwecx2H0dVqv7lBMwwXNY6RN7TBFhBx+CCsDuYM6R5/o4qfRtUyyKzpNZMBJyuPP56XAhcBJeXiwg==
+"@microsoft/api-extractor-model@7.26.2":
+  version "7.26.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.26.2.tgz#b04121b645ef6f00c13262772a0a6019e1923248"
+  integrity sha512-V9tTHbYTNelTrNDXBzeDlszq29nQcjJdP6s27QJiATbqSRjEbKTeztlSVsCRHL2Wkkv5IN5jT4xkYjnFFPbK0A==
   dependencies:
     "@microsoft/tsdoc" "0.14.2"
     "@microsoft/tsdoc-config" "~0.16.1"
-    "@rushstack/node-core-library" "3.54.0"
+    "@rushstack/node-core-library" "3.55.0"
 
 "@microsoft/api-extractor@^7.33.5":
-  version "7.34.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.34.1.tgz#a44e32c8ad15dd852cb2bf799d473480b69c112c"
-  integrity sha512-ZMMfMJuhdW0m0Mr7J+4rfM9ZWUJTQnHVpTGWL7Jo05Ai3lPKdONTdnC9Nz39T+EBV4FDWFr9BvOd4IvBkyKqmQ==
+  version "7.34.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.34.2.tgz#bebff56a90855d6b11d6095525e24d12cab22568"
+  integrity sha512-oREyUU7p3JgjrqapJxEHe83gA1SXOWgaA4XCiY9PvsiLkgGHtn2ibTRgw9GCI/4kZzcb+OQv5waUDxsnQSKfwQ==
   dependencies:
-    "@microsoft/api-extractor-model" "7.26.1"
+    "@microsoft/api-extractor-model" "7.26.2"
     "@microsoft/tsdoc" "0.14.2"
     "@microsoft/tsdoc-config" "~0.16.1"
-    "@rushstack/node-core-library" "3.54.0"
+    "@rushstack/node-core-library" "3.55.0"
     "@rushstack/rig-package" "0.3.17"
     "@rushstack/ts-command-line" "4.13.1"
     colors "~1.2.1"
@@ -2084,10 +2084,10 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@rushstack/node-core-library@3.54.0", "@rushstack/node-core-library@^3.53.2":
-  version "3.54.0"
-  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.54.0.tgz#a3419a9b151a245b77ca8c8a23c254efedd43d79"
-  integrity sha512-QOfjrilrhVbJx5ahDhMzJ+izWJU+EFIbU9N2P1a3PSenQgIthWl68DoCLQUjsHqfsA4YxlABFfuYKoPV/GlTOg==
+"@rushstack/node-core-library@3.55.0", "@rushstack/node-core-library@^3.53.2":
+  version "3.55.0"
+  resolved "https://registry.yarnpkg.com/@rushstack/node-core-library/-/node-core-library-3.55.0.tgz#ecb4dd8dc0936e6e8158dd731e3e4d6b0268f6c6"
+  integrity sha512-6lSel8w3DeGaD/JCKw64wfezEBijlCQlMwBoYg9Ci5VPy+dZ+FpBkIBrY8mi3Ge4xNzr4gyTbQ5XEt0QP1Kv/w==
   dependencies:
     colors "~1.2.1"
     fs-extra "~7.0.1"
@@ -3985,12 +3985,12 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
-"@ts-morph/common@~0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.17.0.tgz#de0d405df10857907469fef8d9363893b4163fd1"
-  integrity sha512-RMSSvSfs9kb0VzkvQ2NWobwnj7TxCA9vI/IjR9bDHqgAyVbu2T0DN4wiKVqomyDWqO7dPr/tErSfq7urQ1Q37g==
+"@ts-morph/common@~0.18.0":
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/@ts-morph/common/-/common-0.18.1.tgz#ca40c3a62c3f9e17142e0af42633ad63efbae0ec"
+  integrity sha512-RVE+zSRICWRsfrkAw5qCAK+4ZH9kwEFv5h0+/YeHTLieWP7F4wWq4JsKFuNWG+fYh/KF+8rAtgdj5zb2mm+DVA==
   dependencies:
-    fast-glob "^3.2.11"
+    fast-glob "^3.2.12"
     minimatch "^5.1.0"
     mkdirp "^1.0.4"
     path-browserify "^1.0.1"
@@ -4269,6 +4269,13 @@
   version "18.0.10"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.10.tgz#3b66dec56aa0f16a6cc26da9e9ca96c35c0b4352"
   integrity sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-slider@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/react-slider/-/react-slider-1.3.1.tgz#a3816989eb4fc172e7df316930f242fec90690fc"
+  integrity sha512-4X2yK7RyCIy643YCFL+bc6XNmcnBtt8n88uuyihvcn5G7Lut23eNQU3q3KmwF7MWIfKfsW5NxCjw0SeDZRtgaA==
   dependencies:
     "@types/react" "*"
 
@@ -5755,9 +5762,9 @@ caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001400:
   integrity sha512-t55jfSaWjCdocnFdKQoO+d2ct9C59UZg4dY3OnUlSZ447r8pUtIKdp0hpAzrGFultmTC+Us+KpKi4GZl/LXlFg==
 
 caniuse-lite@^1.0.30001406:
-  version "1.0.30001449"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz#a8d11f6a814c75c9ce9d851dc53eb1d1dfbcd657"
-  integrity sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==
+  version "1.0.30001450"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001450.tgz#022225b91200589196b814b51b1bbe45144cf74f"
+  integrity sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -7387,7 +7394,7 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.2.11, fast-glob@^3.2.12, fast-glob@^3.2.9:
+fast-glob@^3.2.12, fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==
@@ -11331,7 +11338,7 @@ prompts@^2.0.1, prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -11671,6 +11678,13 @@ react-sizeme@^3.0.1:
     invariant "^2.2.4"
     shallowequal "^1.1.0"
     throttle-debounce "^3.0.1"
+
+react-slider@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-slider/-/react-slider-2.0.4.tgz#21c656ffabc3bb4481cf6b49e6d647baeda83572"
+  integrity sha512-sWwQD01n6v+MbeLCYthJGZPc0kzOyhQHyd0bSo0edg+IAxTVQmj3Oy4SBK65eX6gNwS9meUn6Z5sIBUVmwAd9g==
+  dependencies:
+    prop-types "^15.8.1"
 
 react-uid@^2.3.2:
   version "2.3.2"
@@ -12111,9 +12125,9 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     inherits "^2.0.1"
 
 rollup@^3.7.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.12.0.tgz#813d88ec11e36108da788fc471b3c81b365a7c29"
-  integrity sha512-4MZ8kA2HNYahIjz63rzrMMRvDqQDeS9LoriJvMuV0V6zIGysP36e9t4yObUfwdT9h/szXoHQideICftcdZklWg==
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.12.1.tgz#2975b97713e4af98c15e7024b88292d7fddb3853"
+  integrity sha512-t9elERrz2i4UU9z7AwISj3CQcXP39cWxgRWLdf4Tm6aKm1eYrqHIgjzXBgb67GNY1sZckTFFi0oMozh3/S++Ig==
   optionalDependencies:
     fsevents "~2.3.2"
 
@@ -13172,12 +13186,12 @@ ts-jest@^29.0.2:
     semver "7.x"
     yargs-parser "^21.0.1"
 
-ts-morph@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-16.0.0.tgz#35caca7c286dd70e09e5f72af47536bf3b6a27af"
-  integrity sha512-jGNF0GVpFj0orFw55LTsQxVYEUOCWBAbR5Ls7fTYE5pQsbW18ssTb/6UXx/GYAEjS+DQTp8VoTw0vqYMiaaQuw==
+ts-morph@17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/ts-morph/-/ts-morph-17.0.1.tgz#d85df4fcf9a1fcda1b331d52c00655f381c932d1"
+  integrity sha512-10PkHyXmrtsTvZSL+cqtJLTgFXkU43Gd0JCc0Rw6GchWbqKe0Rwgt1v3ouobTZwQzF1mGhDeAlWYBMGRV7y+3g==
   dependencies:
-    "@ts-morph/common" "~0.17.0"
+    "@ts-morph/common" "~0.18.0"
     code-block-writer "^11.0.3"
 
 ts-node@^10.9.1:
@@ -13677,9 +13691,9 @@ vfile@^4.0.0:
     vfile-message "^2.0.0"
 
 vite-plugin-dts@^1.7.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/vite-plugin-dts/-/vite-plugin-dts-1.7.1.tgz#7090237333a023a78bbcf7ce8e042531422f233a"
-  integrity sha512-2oGMnAjcrZN7jM1TloiS1b1mCn42s3El04ix2RFhId5P1WfMigF8WAwsqT6a6jk0Yso8t7AeZsBkkxYShR0hBQ==
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/vite-plugin-dts/-/vite-plugin-dts-1.7.2.tgz#75c581b5c015a5b437d213454e1fd2bc94223b43"
+  integrity sha512-55Jwfv6n8gAlRSVGCpIY13TCqadtaKex9d2mCbaSxMFAU06suMDsFhIch1x55eptpC2RpeiresqbTjhN2HSEtQ==
   dependencies:
     "@microsoft/api-extractor" "^7.33.5"
     "@rollup/pluginutils" "^5.0.2"
@@ -13688,7 +13702,7 @@ vite-plugin-dts@^1.7.1:
     fast-glob "^3.2.12"
     fs-extra "^10.1.0"
     kolorist "^1.6.0"
-    ts-morph "^16.0.0"
+    ts-morph "17.0.1"
 
 vite@^4.0.0, vite@^4.0.4:
   version "4.0.4"


### PR DESCRIPTION
For JIRA: "EPO-7602 #IN-REVIEW #comment add Slider component"

Rebuild of the Slider component that exists in the Skyviewer. There are some changes I made in implementation that affect the visuals, we can discuss them if need be. We have a use case already for colored slider tracks (Color Filter widget) and implementing the colored tracks revealed that there were some hacks in place. The biggest visual change is that the thumbs are now on top of the tracks rather than floating beneath so as to hide the meeting place between two tracks, which appears to be how react-slider intended thumb placement to be.