### PR TITLE
[C] do prefetch false and miscellany

### DIFF
--- a/packages/epo-react-lib/package.json
+++ b/packages/epo-react-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rubin-epo/epo-react-lib",
   "description": "Rubin Observatory Education & Public Outreach team React UI library.",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "author": "Rubin EPO",
   "license": "MIT",
   "homepage": "https://lsst-epo.github.io/epo-react-lib",

--- a/packages/epo-react-lib/src/atomic/Button/Button.tsx
+++ b/packages/epo-react-lib/src/atomic/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode, HTMLProps } from "react";
+import { forwardRef, HTMLProps, PropsWithChildren } from "react";
 import { IconKey } from "@/svg/icons";
 import IconComposer from "@/svg/IconComposer";
 import * as Styled from "./styles";
@@ -6,7 +6,6 @@ import * as Styled from "./styles";
 export type ButtonStyleAs = "primary" | "secondary" | "tertiary" | "educator";
 
 export interface ButtonProps extends HTMLProps<HTMLButtonElement> {
-  children?: ReactNode;
   className?: string;
   icon?: IconKey;
   iconSize?: number;
@@ -18,7 +17,7 @@ export interface ButtonProps extends HTMLProps<HTMLButtonElement> {
   isInactive?: boolean;
 }
 
-const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+const Button = forwardRef<HTMLButtonElement, PropsWithChildren<ButtonProps>>(
   (
     {
       children,

--- a/packages/epo-react-lib/src/atomic/Buttonish/Buttonish.tsx
+++ b/packages/epo-react-lib/src/atomic/Buttonish/Buttonish.tsx
@@ -3,14 +3,16 @@ import Link from "next/link";
 import { isInternalUrl } from "@/helpers/index";
 import Button, { ButtonProps } from "@/atomic/Button";
 
-interface ButtonishProps extends Omit<ButtonProps, "children"> {
+interface ButtonishProps extends ButtonProps {
   text: string;
   url?: string;
+  prefetch?: boolean;
 }
 
 const Buttonish: FunctionComponent<ButtonishProps> = ({
   text,
   url,
+  prefetch = false,
   ...props
 }) => {
   if (!url) return null;
@@ -23,7 +25,7 @@ const Buttonish: FunctionComponent<ButtonishProps> = ({
     );
   } else {
     return (
-      <Link legacyBehavior href={url} passHref>
+      <Link legacyBehavior href={url} prefetch={prefetch} passHref>
         <Button as="a" {...(props as any)}>
           {text}
         </Button>

--- a/packages/epo-react-lib/src/atomic/MixedLink/MixedLink.tsx
+++ b/packages/epo-react-lib/src/atomic/MixedLink/MixedLink.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, HTMLProps, ReactNode } from "react";
+import { FunctionComponent, HTMLProps, PropsWithChildren } from "react";
 import { UrlObject } from "url";
 import Link from "next/link";
 import ExternalLink from "@/atomic/ExternalLink";
@@ -23,7 +23,6 @@ interface MixedLinkElement {
 }
 
 interface MixedLinkProps extends HTMLProps<HTMLAnchorElement> {
-  children?: ReactNode;
   type?: string;
   url: string;
   customText?: string;
@@ -39,9 +38,10 @@ interface MixedLinkProps extends HTMLProps<HTMLAnchorElement> {
       | ReadonlyArray<number>
       | ReadonlyArray<boolean>;
   };
+  prefetch?: boolean;
 }
 
-const MixedLink: FunctionComponent<MixedLinkProps> = ({
+const MixedLink: FunctionComponent<PropsWithChildren<MixedLinkProps>> = ({
   children,
   className,
   customText,
@@ -49,6 +49,7 @@ const MixedLink: FunctionComponent<MixedLinkProps> = ({
   params,
   text,
   url,
+  prefetch = false,
   ...restProps
 }) => {
   if (!isInternalUrl(url)) {
@@ -68,7 +69,13 @@ const MixedLink: FunctionComponent<MixedLinkProps> = ({
     };
 
     return (
-      <Link href={href} passHref className={className} {...(restProps as any)}>
+      <Link
+        href={href}
+        passHref
+        className={className}
+        prefetch={prefetch}
+        {...(restProps as any)}
+      >
         {children ? children : customText ?? text}
       </Link>
     );

--- a/packages/epo-react-lib/src/atomic/Toast/Toast.tsx
+++ b/packages/epo-react-lib/src/atomic/Toast/Toast.tsx
@@ -1,13 +1,12 @@
-import { FunctionComponent, ReactNode } from "react";
+import { FunctionComponent, PropsWithChildren } from "react";
 
-interface ToastProps {
-  children: ReactNode;
+export interface ToastProps {
   className?: string;
   /** list of ID's that contributed to this status message eg. if clicking on \<svg id="mySvg"/> created a message, pass ['mySvg'] */
   forIds?: string[];
 }
 
-const Toast: FunctionComponent<ToastProps> = ({
+const Toast: FunctionComponent<PropsWithChildren<ToastProps>> = ({
   children,
   className,
   forIds,

--- a/packages/epo-react-lib/src/layout/MasonryGrid/MasonryGridTile.tsx
+++ b/packages/epo-react-lib/src/layout/MasonryGrid/MasonryGridTile.tsx
@@ -10,6 +10,7 @@ interface TileProps {
   isVideo: boolean;
   link: string;
   title: string;
+  prefetch?: boolean;
 }
 
 const Tile: FunctionComponent<TileProps> = ({
@@ -17,9 +18,10 @@ const Tile: FunctionComponent<TileProps> = ({
   isVideo,
   link,
   title,
+  prefetch = false,
 }) => {
   return (
-    <Link legacyBehavior href={link} passHref>
+    <Link legacyBehavior href={link} passHref prefetch={prefetch}>
       <Styled.TileLink>
         <ResponsiveImage image={image} ratio="16:9" title={title} />
         {isVideo && (

--- a/packages/epo-react-lib/src/layout/MasonryGrid/styles.ts
+++ b/packages/epo-react-lib/src/layout/MasonryGrid/styles.ts
@@ -5,6 +5,7 @@ export const TileLink = styled.a`
   position: relative;
   transition: filter 0.2s;
   &:hover,
+  &.focus-visible,
   &:focus-visible {
     img {
       filter: invert(25%) sepia(80%) saturate(102%) hue-rotate(130deg)


### PR DESCRIPTION
Set all Next `Link` components to prefetch=false by default with prop options for overrides.

Some additional cleanup, detangling some Typescript interfaces for the updated components and exporting the interfaces for the Toast (resolves #75 )