### PR TITLE
[F] SlideoutMenu

### DIFF
--- a/packages/epo-react-lib/CHANGELOG.md
+++ b/packages/epo-react-lib/CHANGELOG.md
@@ -10,3 +10,8 @@
 ## 1.2.7
 
 - add `ProgressRadial` variant with same API as `ProgressBar`
+
+## 1.2.8
+
+- add `SlideoutMenu`, `MenuGroup`, `MenuItem`, and `MenuItemRadio`
+- add `--button-text-align` CSS variable to `Button`

--- a/packages/epo-react-lib/CHANGELOG.md
+++ b/packages/epo-react-lib/CHANGELOG.md
@@ -15,3 +15,4 @@
 
 - add `SlideoutMenu`, `MenuGroup`, `MenuItem`, and `MenuItemRadio`
 - add `--button-text-align` CSS variable to `Button`
+- add event listener and focus trap hooks.

--- a/packages/epo-react-lib/package.json
+++ b/packages/epo-react-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rubin-epo/epo-react-lib",
   "description": "Rubin Observatory Education & Public Outreach team React UI library.",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "author": "Rubin EPO",
   "license": "MIT",
   "homepage": "https://lsst-epo.github.io/epo-react-lib",

--- a/packages/epo-react-lib/package.json
+++ b/packages/epo-react-lib/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "flickity": "^3.0.0",
+    "focus-trap": "^7.4.1",
     "react-player": "^2.11.0",
     "react-share": "^4.4.1",
     "react-slider": "^2.0.4",

--- a/packages/epo-react-lib/package.json
+++ b/packages/epo-react-lib/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "flickity": "^3.0.0",
-    "focus-trap": "^7.4.1",
+    "focus-trap": "^7.4.2",
     "react-player": "^2.11.0",
     "react-share": "^4.4.1",
     "react-slider": "^2.0.4",

--- a/packages/epo-react-lib/src/atomic/Button/styles.ts
+++ b/packages/epo-react-lib/src/atomic/Button/styles.ts
@@ -12,6 +12,9 @@ interface StyledButtonProps {
 export const Button = styled.button<StyledButtonProps>`
   ${({ $styleAs = "primary" }) => aButtonTheme($styleAs)}
   ${aButton}
+
+  --button-text-align: center;
+
   align-items: center;
   gap: 10px;
   font-size: ${fluidScale("20px", "16px")};
@@ -34,5 +37,5 @@ export const Button = styled.button<StyledButtonProps>`
 
 export const ButtonText = styled.span`
   flex: 1 1 auto;
-  text-align: center;
+  text-align: var(--button-text-align);
 `;

--- a/packages/epo-react-lib/src/contexts/Menu.ts
+++ b/packages/epo-react-lib/src/contexts/Menu.ts
@@ -2,7 +2,7 @@ import { createContext } from "react";
 
 const MenuContext =
   createContext<{
-    menuItems: Set<HTMLButtonElement>;
+    menuItems: Set<HTMLButtonElement | HTMLDivElement>;
     currentIndex: number;
   } | null>(null);
 

--- a/packages/epo-react-lib/src/contexts/Menu.ts
+++ b/packages/epo-react-lib/src/contexts/Menu.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+const MenuContext =
+  createContext<{
+    menuItems: Set<HTMLButtonElement>;
+    currentIndex: number;
+  } | null>(null);
+
+export default MenuContext;

--- a/packages/epo-react-lib/src/hooks/listeners.js
+++ b/packages/epo-react-lib/src/hooks/listeners.js
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+
+const useEventListener = (event, callback) => {
+  useEffect(() => {
+    window.addEventListener(event, callback);
+    return () => window.removeEventListener(event, callback);
+  }, [event, callback]);
+};
+
+export const useKeyDownEvent = callback => {
+  useEventListener('keydown', callback);
+};
+
+export const useClickEvent = callback => {
+  useEventListener('click', callback);
+};
+
+// Hook
+export const useOnClickOutside = (ref, handler) => {
+  useEffect(
+    () => {
+      const listener = event => {
+        // Do nothing if clicking ref's element or descendent elements
+        if (!ref.current || ref.current.contains(event.target)) {
+          return;
+        }
+
+        handler(event);
+      };
+
+      document.addEventListener('mousedown', listener);
+      document.addEventListener('touchstart', listener);
+
+      return () => {
+        document.removeEventListener('mousedown', listener);
+        document.removeEventListener('touchstart', listener);
+      };
+    },
+    // Add ref and handler to effect dependencies
+    // It's worth noting that because passed in handler is a new ...
+    // ... function on every render that will cause this effect ...
+    // ... callback/cleanup to run every render. It's not a big deal ...
+    // ... but to optimize you can wrap handler in useCallback before ...
+    // ... passing it into this hook.
+    [ref, handler]
+  );
+};

--- a/packages/epo-react-lib/src/hooks/useFocusTrap.ts
+++ b/packages/epo-react-lib/src/hooks/useFocusTrap.ts
@@ -1,0 +1,48 @@
+import { createFocusTrap, FocusTrap } from "focus-trap";
+import { useEffect } from "react";
+
+interface Options {
+  escapeDeactivates?: boolean;
+  clickOutsideDeactivates?: boolean;
+}
+
+export function useFocusTrap(
+  elementRef: React.MutableRefObject<HTMLDivElement | null>,
+  showing: boolean,
+  options: Options = {}
+) {
+  useEffect(() => {
+    let trap: FocusTrap;
+
+    function focusElement() {
+      if (!elementRef.current) {
+        console.error("No element found to found");
+        return;
+      }
+
+      trap = createFocusTrap(elementRef.current, {
+        escapeDeactivates: false,
+        clickOutsideDeactivates: true,
+        fallbackFocus: '[tabindex="-1"]',
+        ...options,
+      });
+
+      trap.activate();
+    }
+
+    function focusTrigger() {
+      if (!trap) {
+        return;
+      }
+
+      trap.deactivate();
+    }
+
+    if (showing) {
+      focusElement();
+      return () => {
+        focusTrigger();
+      };
+    }
+  }, [showing]);
+}

--- a/packages/epo-react-lib/src/index.ts
+++ b/packages/epo-react-lib/src/index.ts
@@ -48,6 +48,12 @@ export { default as Columns } from "@/layout/Columns";
 export { default as Container } from "@/layout/Container";
 export { default as Grid } from "@/layout/Grid";
 export { default as MasonryGrid } from "@/layout/MasonryGrid";
+export {
+  SlideoutMenu,
+  MenuGroup,
+  MenuItem,
+  MenuItemRadio,
+} from "@/layout/SlideoutMenu";
 
 // SVG
 export { default as IconComposer } from "@/svg/IconComposer";

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/MenuGroup/MenuGroup.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/MenuGroup/MenuGroup.tsx
@@ -1,0 +1,29 @@
+import { FunctionComponent, PropsWithChildren } from "react";
+import {
+  StyledMenuGroup,
+  StyledSeparator,
+  StyledMenuGroupTitle,
+} from "./styles";
+
+interface MenuGroupProps {
+  title: string;
+}
+
+const MenuGroup: FunctionComponent<PropsWithChildren<MenuGroupProps>> = ({
+  title,
+  children,
+}) => {
+  return (
+    <>
+      <StyledMenuGroup role="group">
+        <StyledMenuGroupTitle>{title}</StyledMenuGroupTitle>
+        {children}
+      </StyledMenuGroup>
+      <StyledSeparator />
+    </>
+  );
+};
+
+MenuGroup.displayName = "Layout.SlideoutMenu.MenuGroup";
+
+export default MenuGroup;

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/MenuGroup/index.ts
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/MenuGroup/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MenuGroup";

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/MenuGroup/styles.ts
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/MenuGroup/styles.ts
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+export const StyledMenuGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+export const StyledMenuGroupTitle = styled.h3`
+  font-weight: var(--FONT_WEIGHT_NORMAL, 400);
+  font-size: 1rem;
+  margin: 0;
+`;
+export const StyledSeparator = styled.hr`
+  background-color: var(--white, #fff);
+  border: 0;
+  height: 1px;
+`;

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItem/MenuItem.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItem/MenuItem.tsx
@@ -1,0 +1,64 @@
+import {
+  FunctionComponent,
+  PropsWithChildren,
+  useContext,
+  useRef,
+  useEffect,
+} from "react";
+import MenuContext from "@/contexts/Menu";
+import { StyledMenuItem, StyledMenuItemWrapper } from "./styles";
+import { ButtonProps } from "@/atomic/Button";
+
+interface MenuItemProps extends ButtonProps {
+  text: string;
+}
+
+const MenuItem: FunctionComponent<PropsWithChildren<MenuItemProps>> = ({
+  text,
+  children,
+  ...buttonProps
+}) => {
+  const menuContext = useContext(MenuContext);
+  const menuItemRef = useRef<HTMLButtonElement>();
+
+  if (!menuContext) {
+    throw new Error("Submenu must be used within a Menu Context");
+  }
+
+  const { menuItems, currentIndex } = menuContext;
+
+  useEffect(() => {
+    const menuItemNode = menuItemRef.current;
+
+    if (menuItemNode) {
+      menuItems && menuItems.add(menuItemNode);
+    }
+
+    return () => {
+      menuItems && menuItemNode && menuItems.delete(menuItemNode);
+    };
+  }, [menuItems, currentIndex]);
+
+  const isActive =
+    menuItemRef.current &&
+    [...menuItems].indexOf(menuItemRef.current) === currentIndex;
+
+  return (
+    <StyledMenuItemWrapper role="none">
+      <StyledMenuItem
+        {...(buttonProps as any)}
+        ref={menuItemRef}
+        role="menuitem"
+        tabIndex={isActive ? 0 : -1}
+        iconSize={20}
+      >
+        {text}
+      </StyledMenuItem>
+      {children}
+    </StyledMenuItemWrapper>
+  );
+};
+
+MenuItem.displayName = "Layout.SlideoutMenu.MenuItem";
+
+export default MenuItem;

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItem/MenuItem.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItem/MenuItem.tsx
@@ -22,7 +22,7 @@ const MenuItem: FunctionComponent<PropsWithChildren<MenuItemProps>> = ({
   const menuItemRef = useRef<HTMLButtonElement>();
 
   if (!menuContext) {
-    throw new Error("Submenu must be used within a Menu Context");
+    throw new Error("Menu item must be used within a Menu Context");
   }
 
   const { menuItems, currentIndex } = menuContext;

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItem/index.ts
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MenuItem";

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItem/styles.ts
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItem/styles.ts
@@ -1,0 +1,30 @@
+import styled from "styled-components";
+import Button from "@/atomic/Button";
+
+export const StyledMenuItemWrapper = styled.div`
+  padding: 0;
+  margin: 0;
+
+  &:first-of-type {
+    margin-block-start: calc(var(--menu-padding) / 2);
+  }
+`;
+
+export const StyledMenuItem = styled(Button)`
+  --button-border-color: transparent;
+  --button-background-color: transparent;
+  --button-text-align: left;
+
+  border: none;
+  stroke-width: 0.25px;
+  width: 100%;
+
+  &:not(:disabled):not([aria-disabled="true"]):hover {
+    text-decoration: underline;
+  }
+  &:not(:disabled):not([aria-disabled="true"]):focus,
+  &:not(:disabled):not([aria-disabled="true"]):focus-visible,
+  &:not(:disabled):not([aria-disabled="true"]).focus-visible {
+    --button-border-color: var(--white, #fff);
+  }
+`;

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItemRadio/MenuItemRadio.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItemRadio/MenuItemRadio.tsx
@@ -1,0 +1,78 @@
+import { FunctionComponent, useContext, useRef, useEffect } from "react";
+import MenuContext from "@/contexts/Menu";
+import { StyledMenuItemRadio, StyledMenuItemWrapper } from "./styles";
+import { useKeyDownEvent } from "@/hooks/listeners";
+
+interface MenuItemRadioProps {
+  text: string;
+  isChecked: boolean;
+  onCheckCallback: (close?: boolean) => void;
+}
+
+const MenuItemRadio: FunctionComponent<MenuItemRadioProps> = ({
+  text,
+  isChecked,
+  onCheckCallback,
+}) => {
+  const menuContext = useContext(MenuContext);
+  const menuItemRef = useRef<HTMLDivElement>(null);
+
+  if (!menuContext) {
+    throw new Error("Menu item must be used within a Menu Context");
+  }
+
+  const { menuItems, currentIndex } = menuContext;
+
+  useEffect(() => {
+    const menuItemNode = menuItemRef.current;
+
+    if (menuItemNode) {
+      menuItems && menuItems.add(menuItemNode);
+    }
+
+    return () => {
+      menuItems && menuItemNode && menuItems.delete(menuItemNode);
+    };
+  }, [menuItems, currentIndex]);
+
+  const isActive =
+    menuItemRef.current &&
+    [...menuItems].indexOf(menuItemRef.current) === currentIndex;
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (!isChecked && isActive) {
+      const { code } = event;
+
+      const keyMap: { [key: string]: () => void } = {
+        Space: () => onCheckCallback && onCheckCallback(),
+        Enter: () => onCheckCallback && onCheckCallback(true),
+      };
+
+      const action = keyMap[code];
+      if (action) {
+        event.preventDefault();
+        action();
+      }
+    }
+  }
+
+  useKeyDownEvent(handleKeyDown);
+
+  return (
+    <StyledMenuItemWrapper role="none">
+      <StyledMenuItemRadio
+        ref={menuItemRef}
+        role="menuitemradio"
+        tabIndex={isActive ? 0 : -1}
+        aria-checked={isChecked}
+        onClick={() => onCheckCallback && onCheckCallback()}
+      >
+        {text}
+      </StyledMenuItemRadio>
+    </StyledMenuItemWrapper>
+  );
+};
+
+MenuItemRadio.displayName = "Layout.SlideoutMenu.MenuItemRadio";
+
+export default MenuItemRadio;

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItemRadio/index.ts
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItemRadio/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MenuItemRadio";

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItemRadio/styles.ts
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/MenuItemRadio/styles.ts
@@ -1,0 +1,56 @@
+import styled from "styled-components";
+import Button from "@/atomic/Button";
+import { aButton, protoButton } from "@/styles/mixins/appearance";
+
+export const StyledMenuItemWrapper = styled.div`
+  padding: 0;
+  margin: 0;
+
+  &:first-of-type {
+    margin-block-start: calc(var(--menu-padding) / 2);
+  }
+`;
+
+export const StyledMenuItemRadio = styled.div`
+  ${protoButton()}
+  ${aButton}
+
+  display: flex;
+  align-items: center;
+  padding-inline: 0;
+  width: 100%;
+  position: relative;
+
+  &::before {
+    background-color: var(--white, #fff);
+    content: "";
+    border-radius: 15px;
+    display: inline-block;
+    width: 30px;
+    height: 30px;
+    position: absolute;
+    right: 0;
+  }
+
+  &[aria-checked="true"] {
+    &::after {
+      background-color: var(--turquoise55, #009fa1);
+      content: "";
+      border-radius: 10px;
+      width: 20px;
+      height: 20px;
+      position: absolute;
+      right: 5px;
+    }
+  }
+
+  &:not(:disabled):not([aria-disabled="true"]):hover {
+    text-decoration: underline;
+  }
+  &:not(:disabled):not([aria-disabled="true"]):focus,
+  &:not(:disabled):not([aria-disabled="true"]):focus-visible,
+  &:not(:disabled):not([aria-disabled="true"]).focus-visible {
+    outline: 3px solid var(--white, #fff);
+    outline-offset: 1px;
+  }
+`;

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.stories.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.stories.tsx
@@ -142,6 +142,7 @@ const LanguageSubmenu: FunctionComponent<{
         callToAction="Choose your language"
         onOpenCallback={() => onOpenCallback && onOpenCallback()}
         onCloseCallback={() => {
+          setIsOpen(false);
           return onCloseCallback && onCloseCallback();
         }}
       >
@@ -187,6 +188,7 @@ const AcknowledgementsSubmenu: FunctionComponent<{
         callToAction="Acknowledgments and Credits"
         onOpenCallback={() => onOpenCallback && onOpenCallback()}
         onCloseCallback={() => {
+          setIsOpen(false);
           return onCloseCallback && onCloseCallback();
         }}
       >

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.stories.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.stories.tsx
@@ -1,0 +1,167 @@
+import {
+  ComponentMeta,
+  ComponentStory,
+  ComponentStoryObj,
+} from "@storybook/react";
+import styled from "styled-components";
+import { FunctionComponent, useRef, useState } from "react";
+
+import SlideoutMenu from ".";
+import MenuGroup from "./MenuGroup";
+import MenuItem from "./MenuItem";
+import { protoButton } from "@/styles/mixins/appearance";
+import IconComposer from "@/svg/IconComposer/IconComposer";
+
+const meta: ComponentMeta<typeof SlideoutMenu> = {
+  component: SlideoutMenu,
+  argTypes: {
+    onCloseCallback: { action: "Closed menu" },
+    onOpenCallback: { action: "Opened menu" },
+  },
+};
+export default meta;
+
+const Wrapper = styled.div`
+  box-sizing: border-box;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+`;
+
+const IconButton = styled.button`
+  ${protoButton()}
+  display: flex;
+  align-items: center;
+  padding: 0.25rem;
+  margin: 2rem;
+
+  &:not(:disabled):not([aria-disabled="true"]):hover,
+  &:not(:disabled):not([aria-disabled="true"]):focus-visible,
+  &:not(:disabled):not([aria-disabled="true"]):focus,
+  &:not(:disabled):not([aria-disabled="true"]).focus-visible {
+    outline: 3px solid var(--black, #000);
+  }
+`;
+
+const AcknowledgementsSubmenu: FunctionComponent<{
+  onOpenCallback: () => void;
+  onCloseCallback: () => void;
+}> = ({ onOpenCallback, onCloseCallback }) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const id = "acknowledgements";
+  return (
+    <MenuItem
+      icon="Info"
+      text="Acknowledgements"
+      onClick={() => setIsOpen(true)}
+      aria-expanded={isOpen}
+      aria-haspopup="true"
+      aria-controls={id}
+    >
+      <SlideoutMenu
+        isOpen={isOpen}
+        id={id}
+        title="About this investigation"
+        callToAction="Acknowledgments and Credits"
+        onOpenCallback={() => onOpenCallback && onOpenCallback()}
+        onCloseCallback={() => {
+          setIsOpen(false);
+          return onCloseCallback && onCloseCallback();
+        }}
+      >
+        <p>
+          This investigation was created by the Education and Public Outreach
+          program of the Vera C. Rubin Observatory Construction project. In an
+          effort to create and test this investigation prior to the start of
+          Operations, we rely on the data of our scientific colleagues. In
+          particular, this investigation has made use of data and/or services
+          provided by the International Astronomical Union’s Minor Planet
+          Center.
+        </p>
+        <p>
+          We thank the following instructors who volunteered to pilot test this
+          investigation:
+        </p>
+        <ul>
+          <li>Chris Bolhuis, Hudsonville High School, Hudsonville, MI</li>
+          <li>
+            Alice Few, Pierce College Ft. Steilacoom, Lakewood, WA and Tacoma
+            Community College, Tacoma, WA
+          </li>
+          <li>Scott Hildreth, Chabot College, Hayward, CA</li>
+          <li>
+            Joe Muise, St. Thomas More Collegiate, Burnaby, British Columbia
+          </li>
+          <li>
+            Denine Voegeli, Plainview-Elgin-Millville Jr. High School, Elgin, MN
+          </li>
+        </ul>
+        <p>
+          The team would also like to thank Siegfried Eggl, Henry Hsieh, and
+          Mike Kelley for useful scientific discussions in the development of
+          this investigation.
+        </p>
+      </SlideoutMenu>
+    </MenuItem>
+  );
+};
+
+const Template: ComponentStory<typeof SlideoutMenu> = ({ ...args }) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [isOpen, setIsOpen] = useState<boolean>(args.isOpen || true);
+  const [isSubMenuOpen, setIsSubMenuOpen] = useState(false);
+
+  const handleClose = () => {
+    args.onCloseCallback && args.onCloseCallback();
+    buttonRef.current && buttonRef.current.focus();
+
+    return setIsOpen(false);
+  };
+
+  return (
+    <Wrapper>
+      <IconButton
+        onClick={() => setIsOpen(true)}
+        aria-haspopup="menu"
+        aria-controls={args.id}
+        ref={buttonRef}
+      >
+        <IconComposer icon="hamburger" />
+      </IconButton>
+      <SlideoutMenu
+        {...args}
+        isOpen={isOpen}
+        isSubMenuOpen={isSubMenuOpen}
+        onCloseCallback={() => handleClose()}
+      >
+        <MenuGroup title="Settings">
+          <MenuItem icon="Globe" text="Language selection" />
+          <MenuItem icon="ArrowUpFromBracket" text="Share this investigation" />
+          <MenuItem icon="QuestionCircle" text="Help" />
+          <AcknowledgementsSubmenu
+            onOpenCallback={() => setIsSubMenuOpen(true)}
+            onCloseCallback={() => setIsSubMenuOpen(false)}
+          />
+        </MenuGroup>
+        <MenuGroup title="Quick access for students">
+          <MenuItem icon="LogOut" text="Log out" />
+        </MenuGroup>
+        <MenuGroup title="Quick access for educators">
+          <MenuItem icon="User" text="Access educator mode" />
+        </MenuGroup>
+      </SlideoutMenu>
+    </Wrapper>
+  );
+};
+
+export const Primary: ComponentStoryObj<typeof SlideoutMenu> = Template.bind(
+  {}
+);
+
+Primary.args = {
+  title: "Main menu",
+  callToAction: "Settings and more",
+  id: "mainMenu",
+};

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.stories.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.stories.tsx
@@ -9,14 +9,85 @@ import { FunctionComponent, useRef, useState } from "react";
 import SlideoutMenu from ".";
 import MenuGroup from "./MenuGroup";
 import MenuItem from "./MenuItem";
+import MenuItemRadio from "./MenuItemRadio";
 import { protoButton } from "@/styles/mixins/appearance";
 import IconComposer from "@/svg/IconComposer/IconComposer";
 
 const meta: ComponentMeta<typeof SlideoutMenu> = {
   component: SlideoutMenu,
   argTypes: {
-    onCloseCallback: { action: "Closed menu" },
-    onOpenCallback: { action: "Opened menu" },
+    title: {
+      type: { name: "string", required: true },
+      description: "Title that will be placed into the heading of the menu.",
+      table: {
+        type: {
+          summary: "string",
+        },
+      },
+    },
+    callToAction: {
+      type: { name: "string", required: true },
+      description:
+        "Subtitle that will be placed beneath the heading of the menu",
+      table: {
+        type: {
+          summary: "string",
+        },
+      },
+    },
+    id: {
+      type: { name: "string", required: true },
+      description: "Unique identifier for this menu",
+      table: {
+        type: {
+          summary: "string",
+        },
+      },
+    },
+    isOpen: {
+      control: "boolean",
+      description: "Open state of the menu",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
+    isSubMenuOpen: {
+      control: "boolean",
+      description: "Open state of the a submenu within the menu",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+        defaultValue: {
+          summary: false,
+        },
+      },
+    },
+    onCloseCallback: {
+      action: "Closed menu",
+      description:
+        "Callback that will occur when the close button is clicked or Escape pressed.",
+      table: {
+        type: {
+          summary: "() => void",
+        },
+      },
+    },
+    onOpenCallback: {
+      action: "Opened menu",
+      description:
+        "Callback that will occur as soon as `isOpen` is changed to `true`",
+      table: {
+        type: {
+          summary: "() => void",
+        },
+      },
+    },
   },
 };
 export default meta;
@@ -45,6 +116,58 @@ const IconButton = styled.button`
   }
 `;
 
+const LanguageSubmenu: FunctionComponent<{
+  onOpenCallback: () => void;
+  onCloseCallback: () => void;
+}> = ({ onOpenCallback, onCloseCallback }) => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [language, setLanguage] = useState<"en" | "es">("en");
+
+  const languages = [
+    { locale: "en", label: "English" },
+    { locale: "es", label: "Español" },
+  ];
+
+  const id = "language";
+  return (
+    <MenuItem
+      icon="Globe"
+      text="Language selection"
+      onClick={() => setIsOpen(true)}
+      aria-expanded={isOpen}
+      aria-haspopup="true"
+      aria-controls={id}
+    >
+      <SlideoutMenu
+        isOpen={isOpen}
+        id={id}
+        title="Language selection"
+        callToAction="Choose your language"
+        onOpenCallback={() => onOpenCallback && onOpenCallback()}
+        onCloseCallback={() => {
+          return onCloseCallback && onCloseCallback();
+        }}
+      >
+        {languages.map(({ locale, label }) => (
+          <MenuItemRadio
+            key={locale}
+            text={label}
+            isChecked={language === locale}
+            onCheckCallback={(close) => {
+              setLanguage(locale as "en" | "es");
+
+              if (close) {
+                setIsOpen(false);
+                return onCloseCallback && onCloseCallback();
+              }
+            }}
+          />
+        ))}
+      </SlideoutMenu>
+    </MenuItem>
+  );
+};
+
 const AcknowledgementsSubmenu: FunctionComponent<{
   onOpenCallback: () => void;
   onCloseCallback: () => void;
@@ -67,7 +190,6 @@ const AcknowledgementsSubmenu: FunctionComponent<{
         callToAction="Acknowledgments and Credits"
         onOpenCallback={() => onOpenCallback && onOpenCallback()}
         onCloseCallback={() => {
-          setIsOpen(false);
           return onCloseCallback && onCloseCallback();
         }}
       >
@@ -137,7 +259,10 @@ const Template: ComponentStory<typeof SlideoutMenu> = ({ ...args }) => {
         onCloseCallback={() => handleClose()}
       >
         <MenuGroup title="Settings">
-          <MenuItem icon="Globe" text="Language selection" />
+          <LanguageSubmenu
+            onOpenCallback={() => setIsSubMenuOpen(true)}
+            onCloseCallback={() => setIsSubMenuOpen(false)}
+          />
           <MenuItem icon="ArrowUpFromBracket" text="Share this investigation" />
           <MenuItem icon="QuestionCircle" text="Help" />
           <AcknowledgementsSubmenu

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.stories.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.stories.tsx
@@ -6,10 +6,7 @@ import {
 import styled from "styled-components";
 import { FunctionComponent, useRef, useState } from "react";
 
-import SlideoutMenu from ".";
-import MenuGroup from "./MenuGroup";
-import MenuItem from "./MenuItem";
-import MenuItemRadio from "./MenuItemRadio";
+import { SlideoutMenu, MenuGroup, MenuItem, MenuItemRadio } from ".";
 import { protoButton } from "@/styles/mixins/appearance";
 import IconComposer from "@/svg/IconComposer/IconComposer";
 

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.test.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.test.tsx
@@ -1,8 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import SlideoutMenu from ".";
-import MenuGroup from "./MenuGroup";
-import MenuItem from "./MenuItem";
+import { SlideoutMenu, MenuGroup, MenuItem } from ".";
 import { IconKey } from "@/svg/icons";
 
 const props = {

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.test.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SlideoutMenu from ".";
+import MenuGroup from "./MenuGroup";
+import MenuItem from "./MenuItem";
+import { IconKey } from "@/svg/icons";
+
+const props = {
+  title: "Main menu",
+  callToAction: "Settings and more",
+  id: "mainMenu",
+  isOpen: true,
+};
+
+const menuItems = [
+  { icon: "LogOut", text: "Log out", id: "item-1" },
+  { icon: "LogOut", text: "Language", id: "item-2" },
+  { icon: "LogOut", text: "Help", id: "item-3" },
+];
+
+describe("Slideout menu", () => {
+  it("is visible when opened", () => {
+    render(<SlideoutMenu {...props} />);
+
+    const menu = screen.getByRole("menu");
+
+    expect(menu).toBeVisible();
+  });
+  it("gives focus to the first menuitem", () => {
+    render(
+      <SlideoutMenu {...props}>
+        <MenuGroup title="Quick access for students">
+          {menuItems.map(({ icon, text, id }) => (
+            <MenuItem icon={icon as IconKey} text={text} id={id} key={id} />
+          ))}
+        </MenuGroup>
+      </SlideoutMenu>
+    );
+
+    expect(document.activeElement?.id).toBe(menuItems[0].id);
+  });
+  it("changes focus using arrow keys", () => {
+    render(
+      <SlideoutMenu {...props}>
+        <MenuGroup title="Quick access for students">
+          {menuItems.map(({ icon, text, id }) => (
+            <MenuItem icon={icon as IconKey} text={text} id={id} key={id} />
+          ))}
+        </MenuGroup>
+      </SlideoutMenu>
+    );
+
+    userEvent.keyboard("{ArrowDown}");
+
+    waitFor(() => {
+      expect(document.activeElement?.id).toBe(menuItems[1].id);
+    });
+  });
+  it("closes the menu when Escape is pressed", () => {
+    render(<SlideoutMenu {...props} />);
+
+    const menu = screen.getByRole("menu");
+
+    userEvent.keyboard("{Esc}");
+
+    waitFor(() => {
+      expect(menu).not.toBeVisible();
+    });
+  });
+});

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.tsx
@@ -146,7 +146,7 @@ const SlideoutMenu: FunctionComponent<PropsWithChildren<SlideoutMenuProps>> = ({
           <StyledMenuTitle
             id={menuTitleId}
             ref={titleRef}
-            tabIndex={menuItems.size === 0 ? -1 : undefined}
+            tabIndex={menuItems.size === 0 ? 0 : undefined}
           >
             {title}
           </StyledMenuTitle>

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.tsx
@@ -8,14 +8,7 @@ import {
 } from "react";
 import { useOnClickOutside, useKeyDownEvent } from "@/hooks/listeners";
 import MenuContext from "@/contexts/Menu";
-import {
-  StyledOverlay,
-  StyledMenuContainer,
-  StyledMenuHeader,
-  StyledMenuTitle,
-  StyledMenuCallToAction,
-  StyledMenuCloseButton,
-} from "./styles";
+import * as Styled from "./styles";
 import { MENU_TRANSITION_TIME } from "./constants";
 import IconComposer from "@/svg/IconComposer/IconComposer";
 
@@ -131,37 +124,37 @@ const SlideoutMenu: FunctionComponent<PropsWithChildren<SlideoutMenuProps>> = ({
   useOnClickOutside(menuRef, handleClose);
 
   return (
-    <StyledOverlay
+    <Styled.Overlay
       role="none"
       aria-hidden={!isOpen}
       style={{ "--visibility": !isHidden && "visible" }}
     >
-      <StyledMenuContainer
+      <Styled.MenuContainer
         ref={menuRef}
         role="menu"
         aria-labelledby={menuTitleId}
         id={menuId}
       >
-        <StyledMenuHeader>
-          <StyledMenuTitle
+        <Styled.MenuHeader>
+          <Styled.MenuTitle
             id={menuTitleId}
             ref={titleRef}
             tabIndex={menuItems.size === 0 ? 0 : undefined}
           >
             {title}
-          </StyledMenuTitle>
-          <StyledMenuCallToAction>{callToAction}</StyledMenuCallToAction>
-          <StyledMenuCloseButton
+          </Styled.MenuTitle>
+          <Styled.MenuCallToAction>{callToAction}</Styled.MenuCallToAction>
+          <Styled.MenuCloseButton
             type="button"
             onClick={() => handleClose()}
             tabIndex={-1}
           >
             <IconComposer icon="close" size={25} />
-          </StyledMenuCloseButton>
-        </StyledMenuHeader>
+          </Styled.MenuCloseButton>
+        </Styled.MenuHeader>
         <MenuContext.Provider value={value}>{children}</MenuContext.Provider>
-      </StyledMenuContainer>
-    </StyledOverlay>
+      </Styled.MenuContainer>
+    </Styled.Overlay>
   );
 };
 

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.tsx
@@ -1,0 +1,164 @@
+import {
+  FunctionComponent,
+  PropsWithChildren,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useOnClickOutside, useKeyDownEvent } from "@/hooks/listeners";
+import MenuContext from "@/contexts/Menu";
+import {
+  StyledOverlay,
+  StyledMenuContainer,
+  StyledMenuHeader,
+  StyledMenuTitle,
+  StyledMenuCallToAction,
+  StyledMenuCloseButton,
+} from "./styles";
+import { MENU_TRANSITION_TIME } from "./constants";
+import IconComposer from "@/svg/IconComposer/IconComposer";
+
+interface SlideoutMenuProps {
+  title: string;
+  callToAction: string;
+  id: string;
+  isOpen: boolean;
+  isSubMenuOpen?: boolean;
+  onOpenCallback?: () => void;
+  onCloseCallback?: () => void;
+}
+
+const SlideoutMenu: FunctionComponent<PropsWithChildren<SlideoutMenuProps>> = ({
+  title,
+  callToAction,
+  id,
+  isOpen = false,
+  isSubMenuOpen = false,
+  onOpenCallback,
+  onCloseCallback,
+  children,
+}) => {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const menuItems = useRef<Set<HTMLButtonElement>>(new Set()).current;
+
+  const [prevIndex, setPrevIndex] = useState<number>();
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isHidden, setIsHidden] = useState(!isOpen);
+
+  const value = useMemo(
+    () => ({ menuItems, currentIndex }),
+    [menuItems, currentIndex]
+  );
+
+  useEffect(() => {
+    if (currentIndex !== prevIndex && isOpen) {
+      setPrevIndex(currentIndex);
+      focusIndex(currentIndex);
+    }
+  }, [menuItems, currentIndex, prevIndex]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setPrevIndex(undefined);
+      focusIndex(currentIndex);
+      setIsHidden(false);
+      onOpenCallback && onOpenCallback();
+    } else {
+      setTimeout(() => {
+        setIsHidden(true);
+      }, MENU_TRANSITION_TIME);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isSubMenuOpen) {
+      focusIndex(currentIndex);
+    }
+  }, [isSubMenuOpen]);
+
+  const handleClose = () => {
+    if (isOpen && !isSubMenuOpen) {
+      return onCloseCallback && onCloseCallback();
+    }
+  };
+
+  const nextItem = () => setCurrentIndex((currentIndex + 1) % menuItems.size);
+  const prevItem = () =>
+    setCurrentIndex((currentIndex - 1 + menuItems.size) % menuItems.size);
+  const firstItem = () => setCurrentIndex(0);
+  const lastItem = () => setCurrentIndex(menuItems.size - 1);
+
+  const focusIndex = (i: number) => {
+    const items = Array.from(menuItems);
+    const item = items[i];
+    if (item) {
+      console.log("im focusin up heree!!!");
+      item.focus();
+    } else {
+      console.log("im focusin here");
+      titleRef.current && titleRef.current.focus();
+    }
+  };
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (isOpen && !isSubMenuOpen) {
+      const { key } = event;
+
+      const keyMap: { [key: string]: () => void } = {
+        ArrowDown: nextItem,
+        ArrowUp: prevItem,
+        Home: firstItem,
+        End: lastItem,
+        Escape: handleClose,
+      };
+
+      const action = keyMap[key];
+      if (action) {
+        event.preventDefault();
+        action();
+      }
+    }
+  }
+
+  const menuId = `slideOutMenu-${id}`;
+  const menuTitleId = `slideOutMenuTitle-${id}`;
+
+  useKeyDownEvent(handleKeyDown);
+  useOnClickOutside(menuRef, handleClose);
+
+  return (
+    <StyledOverlay
+      role="none"
+      aria-hidden={!isOpen}
+      style={{ "--visibility": !isHidden && "visible" }}
+    >
+      <StyledMenuContainer
+        ref={menuRef}
+        role="menu"
+        aria-labelledby={menuTitleId}
+        id={menuId}
+      >
+        <StyledMenuHeader>
+          <StyledMenuTitle
+            id={menuTitleId}
+            ref={titleRef}
+            tabIndex={menuItems.size === 0 ? -1 : undefined}
+          >
+            {title}
+          </StyledMenuTitle>
+          <StyledMenuCallToAction>{callToAction}</StyledMenuCallToAction>
+          <StyledMenuCloseButton type="button" onClick={() => handleClose()}>
+            <IconComposer icon="close" size={25} />
+          </StyledMenuCloseButton>
+        </StyledMenuHeader>
+        <MenuContext.Provider value={value}>{children}</MenuContext.Provider>
+      </StyledMenuContainer>
+    </StyledOverlay>
+  );
+};
+
+SlideoutMenu.displayName = "Layout.SlideoutMenu";
+
+export default SlideoutMenu;

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/constants.ts
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/constants.ts
@@ -1,0 +1,3 @@
+export const MENU_SLIDE_TIME: number = 400;
+export const MENU_SLIDE_DELAY: number = 200;
+export const MENU_TRANSITION_TIME: number = MENU_SLIDE_TIME + MENU_SLIDE_DELAY;

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/index.ts
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/index.ts
@@ -1,1 +1,4 @@
-export { default } from "./SlideoutMenu";
+export { default as SlideoutMenu } from "./SlideoutMenu";
+export { default as MenuGroup } from "./MenuGroup";
+export { default as MenuItem } from "./MenuItem";
+export { default as MenuItemRadio } from "./MenuItemRadio";

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/index.ts
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SlideoutMenu";

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/styles.ts
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/styles.ts
@@ -7,7 +7,7 @@ import {
   MENU_SLIDE_DELAY,
 } from "./constants";
 
-export const StyledOverlay = styled.div`
+export const Overlay = styled.div`
   --menu-transition-time: ${MENU_TRANSITION_TIME}ms;
   --menu-slide-time: ${MENU_SLIDE_TIME}ms;
   --menu-slide-delay: ${MENU_SLIDE_DELAY}ms;
@@ -35,7 +35,7 @@ export const StyledOverlay = styled.div`
   }
 `;
 
-export const StyledMenuContainer = styled.div`
+export const MenuContainer = styled.div`
   --menu-padding: var(--PADDING_SMALL, 20px);
 
   background-color: var(--neutral95, #1f2121);
@@ -61,7 +61,7 @@ export const StyledMenuContainer = styled.div`
     --menu-padding: var(--PADDING_MEDIUM, 40px);
   }
 `;
-export const StyledMenuHeader = styled.div`
+export const MenuHeader = styled.div`
   margin: 0;
   padding: 0;
   border-bottom: 1px solid var(--white, #fff);
@@ -75,18 +75,18 @@ export const StyledMenuHeader = styled.div`
     "callToAction close";
   align-items: center;
 `;
-export const StyledMenuTitle = styled.h2`
+export const MenuTitle = styled.h2`
   font-weight: var(--FONT_WEIGHT_NORMAL, 400);
   font-size: 0.8rem;
   grid-area: title;
   margin: 0;
   padding: 0;
 `;
-export const StyledMenuCallToAction = styled.span`
+export const MenuCallToAction = styled.span`
   font-weight: var(--FONT_WEIGHT_BOLD, 600);
   grid-area: callToAction;
 `;
-export const StyledMenuCloseButton = styled.button`
+export const MenuCloseButton = styled.button`
   ${protoButton()}
   aspect-ratio: 1;
   color: var(--white, #fff);

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/styles.ts
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/styles.ts
@@ -1,0 +1,104 @@
+import styled from "styled-components";
+import { zStack, BREAK_TABLET_MIN } from "@/styles/abstracts";
+import { protoButton } from "@/styles/mixins/appearance";
+import {
+  MENU_TRANSITION_TIME,
+  MENU_SLIDE_TIME,
+  MENU_SLIDE_DELAY,
+} from "./constants";
+
+export const StyledOverlay = styled.div`
+  --menu-transition-time: ${MENU_TRANSITION_TIME}ms;
+  --menu-slide-time: ${MENU_SLIDE_TIME}ms;
+  --menu-slide-delay: ${MENU_SLIDE_DELAY}ms;
+
+  --background-color: transparent;
+  --pointer-events: none;
+  --transform: translateX(-100%);
+
+  background-color: var(--background-color, transparent);
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: ${zStack.dialog};
+  transition: background-color var(--menu-slide-time);
+  transition-delay: var(--menu-slide-delay);
+  pointer-events: var(--pointer-events);
+  visibility: var(--visibility, hidden);
+
+  &:not([aria-hidden="true"]) {
+    --background-color: rgba(0, 0, 0, 0.7);
+    --pointer-events: auto;
+    --transform: translateX(0);
+  }
+`;
+
+export const StyledMenuContainer = styled.div`
+  --menu-padding: var(--PADDING_SMALL, 20px);
+
+  background-color: var(--neutral95, #1f2121);
+  box-sizing: border-box;
+  color: var(--white, #fff);
+  padding: var(--menu-padding);
+  height: 100%;
+  width: 20rem;
+  max-width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transition: transform var(--menu-slide-time) ease-in;
+  transition-delay: var(--menu-slide-delay);
+  transform: var(--transform);
+  overflow-y: auto;
+
+  & > * + * {
+    margin-block-start: calc(var(--menu-padding) / 2);
+  }
+
+  @media screen and (min-width: ${BREAK_TABLET_MIN}) {
+    --menu-padding: var(--PADDING_MEDIUM, 40px);
+  }
+`;
+export const StyledMenuHeader = styled.div`
+  margin: 0;
+  padding: 0;
+  border-bottom: 1px solid var(--white, #fff);
+  padding-block-end: calc(var(--menu-padding) / 2);
+
+  display: grid;
+  grid-template-columns: 1fr min-content;
+  grid-template-rows: min-content min-content;
+  grid-template-areas:
+    "title close"
+    "callToAction close";
+  align-items: center;
+`;
+export const StyledMenuTitle = styled.h2`
+  font-weight: var(--FONT_WEIGHT_NORMAL, 400);
+  font-size: 0.8rem;
+  grid-area: title;
+  margin: 0;
+  padding: 0;
+`;
+export const StyledMenuCallToAction = styled.span`
+  font-weight: var(--FONT_WEIGHT_BOLD, 600);
+  grid-area: callToAction;
+`;
+export const StyledMenuCloseButton = styled.button`
+  ${protoButton()}
+  aspect-ratio: 1;
+  color: var(--white, #fff);
+  display: flex;
+  align-items: center;
+  grid-area: close;
+  padding: 0.25rem;
+
+  &:not(:disabled):not([aria-disabled="true"]):hover,
+  &:not(:disabled):not([aria-disabled="true"]):focus,
+  &:not(:disabled):not([aria-disabled="true"]):focus-visible,
+  &:not(:disabled):not([aria-disabled="true"]).focus-visible {
+    outline: 3px solid var(--white, #fff);
+  }
+`;

--- a/packages/epo-react-lib/src/styles/mixins/appearance.ts
+++ b/packages/epo-react-lib/src/styles/mixins/appearance.ts
@@ -81,6 +81,7 @@ export const aButton = css`
   transition: background-color 0.2s, color 0.2s, border-color 0.2s;
 
   &:not(:disabled):not([aria-disabled="true"]):hover,
+  &:not(:disabled):not([aria-disabled="true"]):focus-visible,
   &:not(:disabled):not([aria-disabled="true"]).focus-visible {
     outline: 3px solid var(--button-border-color);
     outline-offset: 1px;
@@ -93,6 +94,7 @@ export const aButton = css`
     pointer-events: none;
 
     &.focus-visible,
+    &:focus-visible,
     &:hover {
       outline: 0;
     }

--- a/packages/epo-react-lib/src/svg/icons/Close.tsx
+++ b/packages/epo-react-lib/src/svg/icons/Close.tsx
@@ -4,7 +4,8 @@ import defaultProps from "./defaultProps";
 
 const Close: FunctionComponent<SVGProps> = ({
   size = 17.414,
-  fill,
+  fill = "currentColor",
+  stroke = "currentColor",
   className,
 }) => {
   const uniqueProps = {
@@ -12,6 +13,7 @@ const Close: FunctionComponent<SVGProps> = ({
     width: size,
     height: size,
     fill,
+    stroke,
     className,
   };
 
@@ -20,9 +22,9 @@ const Close: FunctionComponent<SVGProps> = ({
   return (
     <svg {...mergedSvgProps}>
       <title>Close icon</title>
-      <g data-name="Group 556055" fill="none" stroke="#000" strokeWidth={2}>
-        <path data-name="Line 9407" d="m.707 16.707 16-16" />
-        <path data-name="Line 9408" d="m.707.707 16 16" />
+      <g strokeWidth={2}>
+        <path d="m.707 16.707 16-16" />
+        <path d="m.707.707 16 16" />
       </g>
     </svg>
   );

--- a/packages/epo-react-lib/src/types/css.d.ts
+++ b/packages/epo-react-lib/src/types/css.d.ts
@@ -1,0 +1,9 @@
+// My css.d.ts file
+import type * as CSS from "csstype";
+
+declare module "csstype" {
+  interface Properties {
+    // Allow any CSS Custom Properties
+    [index: `--${string}`]: any;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6718,6 +6718,13 @@ focus-lock@^0.8.0:
   dependencies:
     tslib "^1.9.3"
 
+focus-trap@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.4.2.tgz#25ad602bfae3284639a26abbf176425d96e47561"
+  integrity sha512-KMjf+H5uDWPkwSQVqE5r/+vOkP5zBWwVBoWPIZxU3gfg+M8IT+Y8s+vXQqZvHEIXyHPKHrSm6m4G4ceF98OZ8w==
+  dependencies:
+    tabbable "^6.1.2"
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -12112,6 +12119,11 @@ synchronous-promise@^2.0.15:
   version "2.0.17"
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.17.tgz#38901319632f946c982152586f2caf8ddc25c032"
   integrity sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==
+
+tabbable@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.1.2.tgz#b0d3ca81d582d48a80f71b267d1434b1469a3703"
+  integrity sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ==
 
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
SlideoutMenu matching the designs for investigations-client and intended for general use across our applications. Test in Storybook. 

- Should match the roles and functions described for the [ARIA menu role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role)
- Should focus the first `menuitem` element OR the heading if there is not element when the menu opens
- Should navigate the `menuitem` elements with arrow keys and be able to use `Enter` and `Space` on them. 
- Should close the menu when escape or the close button is clicked (close button is not focusable, menus should only have menuitems focusable, tabbing should move to the next non-menu element)
- Closing a submenu should return focus to the opening `menuitem`
- Clicking outside the menu or submenu should close it.

![image](https://github.com/lsst-epo/epo-react-lib/assets/11721838/c7838d68-e823-4457-bc24-39780c8ce7cf)
