### PR TITLE
Added className, id to SelectListbox

### DIFF
--- a/packages/epo-react-lib/package.json
+++ b/packages/epo-react-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rubin-epo/epo-react-lib",
   "description": "Rubin Observatory Education & Public Outreach team React UI library.",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "author": "Rubin EPO",
   "license": "MIT",
   "homepage": "https://lsst-epo.github.io/epo-react-lib",

--- a/packages/epo-react-lib/src/form/SelectListbox/SelectListbox.tsx
+++ b/packages/epo-react-lib/src/form/SelectListbox/SelectListbox.tsx
@@ -18,6 +18,8 @@ type SelectListboxProps<TMultiselect = boolean> = TMultiselect extends true
       namespace?: string;
       maxWidth?: string;
       width?: string;
+      className?: string;
+      id?: string;
     }
   : {
       value: string | null;
@@ -30,6 +32,8 @@ type SelectListboxProps<TMultiselect = boolean> = TMultiselect extends true
       namespace?: string;
       maxWidth?: string;
       width?: string;
+      className?: string;
+      id?: string;
     };
 
 const SelectListbox: FunctionComponent<SelectListboxProps> = ({
@@ -43,6 +47,7 @@ const SelectListbox: FunctionComponent<SelectListboxProps> = ({
   isMultiselect = false,
   maxWidth = "200px",
   width,
+  className,
 }) => {
   const uid = namespace || useUID();
   const {
@@ -92,8 +97,13 @@ const SelectListbox: FunctionComponent<SelectListboxProps> = ({
 
   return (
     <Styled.SelectContainer
+      style={{
+        "--min-width": `${selectWidth}px`,
+        "--max-width": maxWidth,
+        "--width": width,
+      }}
       ref={wrapperRef}
-      {...{ width, maxWidth, minWidth: selectWidth }}
+      className={className}
     >
       <Styled.SelectButton
         onClick={() => setIsDropdownOpen(!isDropdownOpen)}

--- a/packages/epo-react-lib/src/form/SelectListbox/SelectListbox.tsx
+++ b/packages/epo-react-lib/src/form/SelectListbox/SelectListbox.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent, useLayoutEffect, useState } from "react";
 import { useUID } from "react-uid";
-import { useTranslation } from "react-i18next";
 import { ListboxOption } from "@/types/select-listbox";
 import IconComposer from "@/svg/IconComposer";
 import * as Styled from "./styles";
@@ -42,7 +41,7 @@ const SelectListbox: FunctionComponent<SelectListboxProps> = ({
   onChangeCallback,
   isDisabled,
   labelledById,
-  placeholder: unsafePlaceholder,
+  placeholder = "Select",
   namespace,
   isMultiselect = false,
   maxWidth = "200px",
@@ -66,7 +65,6 @@ const SelectListbox: FunctionComponent<SelectListboxProps> = ({
     isMultiselect,
   } as any);
   const [selectWidth, setSelectWidth] = useState(0);
-  const { t } = useTranslation();
 
   useLayoutEffect(() => {
     if (listRef.current) {
@@ -86,10 +84,6 @@ const SelectListbox: FunctionComponent<SelectListboxProps> = ({
 
   const getOptionFromValue = (value: string | null) =>
     options.find((o) => o.value === value);
-
-  const placeholder = unsafePlaceholder
-    ? unsafePlaceholder
-    : t("select_listbox.placeholder");
 
   const selectionLabel = Array.isArray(value)
     ? value.map((v) => getOptionFromValue(v)?.label).join(", ")

--- a/packages/epo-react-lib/src/form/SelectListbox/styles.ts
+++ b/packages/epo-react-lib/src/form/SelectListbox/styles.ts
@@ -1,19 +1,8 @@
 import { zStack } from "@/styles/abstracts";
 import { protoButton } from "@/styles/mixins/appearance";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
-export const SelectContainer = styled.div.attrs<{
-  minWidth?: number;
-  width?: string;
-}>(({ minWidth = 0, width }) =>
-  width
-    ? null
-    : {
-        style: {
-          minWidth,
-        },
-      }
-)<{ maxWidth: string; width?: string }>`
+export const SelectContainer = styled.div`
   --select-background-color: var(--turquoise10, #d9f7f6);
   --select-border-color: var(--turquoise85, #12726c);
   --select-color: var(--turquoise95, #1f2121);
@@ -23,11 +12,9 @@ export const SelectContainer = styled.div.attrs<{
   display: inline-block;
   font-size: 14px;
   position: relative;
-  ${({ maxWidth, width }) =>
-    css`
-      max-width: ${maxWidth};
-      ${width ? `width: ${width};` : ""}
-    `};
+  min-width: var(--min-width);
+  max-width: var(--max-width);
+  width: var(--width);
 `;
 
 export const SelectDropdown = styled.ul`


### PR DESCRIPTION
Adding className and id attributes to the SelectListbox component so it can be re-styled and used in forms. I have also implemented some of the changes that are made in v2.0.0 of the library to use CSS variables instead of styled-components interpolations. Additionally I have removed the `react-i18next` useTranslation hook from the placeholder.

Given the complexity of server/client translations and simply importing `useTranslation` no longer serving either purpose, I think that going forward library components should simply have static, English only, placeholders and other text display that can be overridden by strings passed in as props. We discussed this during library development and I was in favor of using `react-i18next` in the library but I can see now the limitations of that approach. 

These changes will also flow upstream to 2.0.0