### PR TITLE
[C] add signature overloads to token

### DIFF
--- a/packages/epo-react-lib/CHANGELOG.md
+++ b/packages/epo-react-lib/CHANGELOG.md
@@ -47,3 +47,7 @@
 - refactor `Container` so that `className` can be properly attached for restyling with `styled-components`
 - add nested example to `Container` storybook
 - remove type exports from main module
+
+## 2.0.2
+
+- add signature overloads to `token`

--- a/packages/epo-react-lib/src/styles/utils/index.ts
+++ b/packages/epo-react-lib/src/styles/utils/index.ts
@@ -109,11 +109,13 @@ export const respond = (
   return respondBase(content, size, operator, aspect);
 };
 
-export const token = (which: string | string[]) => {
+export function token(which: string): string;
+export function token(which: string[]): { [key: string]: string };
+export function token(which: unknown): unknown {
   if (typeof which === "string") {
     return tokens[which];
   } else if (Array.isArray(which)) {
-    let obj = which.reduce(function (result: { [key: string]: string }, item) {
+    let obj = which.reduce((result: { [key: string]: string }, item) => {
       result[item] = tokens[item];
       return result;
     }, {});
@@ -121,7 +123,7 @@ export const token = (which: string | string[]) => {
   } else {
     return tokens;
   }
-};
+}
 
 export const ScreenreaderText = styled.span`
   ${aHidden}


### PR DESCRIPTION
Add signature overload to the `token` util so that retrieving a token by string returns a string, and retrieving by array retrieves an object. 