### PR TITLE
[F] Refactor of Color Filter Tool

### DIFF
--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubin-epo/epo-widget-lib",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Rubin Observatory Education & Public Outreach team React scientific and educational widgets.",
   "author": "Rubin EPO",
   "license": "MIT",

--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubin-epo/epo-widget-lib",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Rubin Observatory Education & Public Outreach team React scientific and educational widgets.",
   "author": "Rubin EPO",
   "license": "MIT",
@@ -86,7 +86,7 @@
     "react-i18next": "^12.2.0"
   },
   "dependencies": {
-    "@rubin-epo/epo-react-lib": "^2.0.8",
+    "@rubin-epo/epo-react-lib": "^2.0.9",
     "lodash": "^4.17.21",
     "styled-components": "^6.1.1",
     "use-resize-observer": "^9.1.0"

--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -86,7 +86,7 @@
     "react-i18next": "^12.2.0"
   },
   "dependencies": {
-    "@rubin-epo/epo-react-lib": "^2.0.4",
+    "@rubin-epo/epo-react-lib": "^2.0.7",
     "lodash": "^4.17.21",
     "styled-components": "^6.1.1",
     "use-resize-observer": "^9.1.0"

--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubin-epo/epo-widget-lib",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Rubin Observatory Education & Public Outreach team React scientific and educational widgets.",
   "author": "Rubin EPO",
   "license": "MIT",

--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubin-epo/epo-widget-lib",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Rubin Observatory Education & Public Outreach team React scientific and educational widgets.",
   "author": "Rubin EPO",
   "license": "MIT",

--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -86,7 +86,7 @@
     "react-i18next": "^12.2.0"
   },
   "dependencies": {
-    "@rubin-epo/epo-react-lib": "^2.0.3",
+    "@rubin-epo/epo-react-lib": "^2.0.4",
     "lodash": "^4.17.21",
     "styled-components": "^6.1.1",
     "use-resize-observer": "^9.1.0"

--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubin-epo/epo-widget-lib",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Rubin Observatory Education & Public Outreach team React scientific and educational widgets.",
   "author": "Rubin EPO",
   "license": "MIT",
@@ -86,7 +86,7 @@
     "react-i18next": "^12.2.0"
   },
   "dependencies": {
-    "@rubin-epo/epo-react-lib": "^2.0.7",
+    "@rubin-epo/epo-react-lib": "^2.0.8",
     "lodash": "^4.17.21",
     "styled-components": "^6.1.1",
     "use-resize-observer": "^9.1.0"

--- a/packages/epo-widget-lib/src/hooks/useImage.ts
+++ b/packages/epo-widget-lib/src/hooks/useImage.ts
@@ -1,0 +1,93 @@
+import { useRef, useState, useLayoutEffect } from "react";
+
+type ImageStatus = "loading" | "loaded" | "failed";
+
+interface useImageProps {
+  url: string;
+  crossOrigin?: "anonymous" | "use-credentials";
+  referrerpolicy?:
+    | "no-referrer"
+    | "no-referrer-when-downgrade"
+    | "origin"
+    | "origin-when-cross-origin"
+    | "same-origin"
+    | "strict-origin"
+    | "strict-origin-when-cross-origin"
+    | "unsafe-url";
+  onLoadCallback?: () => void;
+  onErrorCallback?: () => void;
+}
+
+function useImage({
+  url,
+  crossOrigin,
+  referrerpolicy,
+  onLoadCallback,
+  onErrorCallback,
+}: useImageProps): [undefined | HTMLImageElement, ImageStatus] {
+  // lets use refs for image and status
+  // so we can update them during render
+  // to have instant update in status/image when new data comes in
+  const statusRef = useRef<ImageStatus>("loading");
+  const imageRef = useRef<HTMLImageElement>();
+
+  // we are not going to use token
+  // but we need to just to trigger state update
+  const [_, setStateToken] = useState(0);
+
+  // keep track of old props to trigger changes
+  const oldUrl = useRef<string>();
+  const oldCrossOrigin = useRef<string>();
+  const oldReferrerPolicy = useRef<string>();
+  if (
+    oldUrl.current !== url ||
+    oldCrossOrigin.current !== crossOrigin ||
+    oldReferrerPolicy.current !== referrerpolicy
+  ) {
+    statusRef.current = "loading";
+    imageRef.current = undefined;
+    oldUrl.current = url;
+    oldCrossOrigin.current = crossOrigin;
+    oldReferrerPolicy.current = referrerpolicy;
+  }
+
+  useLayoutEffect(
+    function () {
+      if (!url) return;
+      var img = document.createElement("img");
+
+      function onload() {
+        statusRef.current = "loaded";
+        imageRef.current = img;
+        onLoadCallback && onLoadCallback();
+        setStateToken(Math.random());
+      }
+
+      function onerror() {
+        statusRef.current = "failed";
+        imageRef.current = undefined;
+        onErrorCallback && onErrorCallback();
+        setStateToken(Math.random());
+      }
+
+      img.addEventListener("load", onload);
+      img.addEventListener("error", onerror);
+      crossOrigin && (img.crossOrigin = crossOrigin);
+      referrerpolicy && (img.referrerPolicy = referrerpolicy);
+      img.src = url;
+
+      return function cleanup() {
+        img.removeEventListener("load", onload);
+        img.removeEventListener("error", onerror);
+      };
+    },
+    [url, crossOrigin, referrerpolicy]
+  );
+
+  // return array because it is better to use in case of several useImage hooks
+  // const [background, backgroundStatus] = useImage(url1);
+  // const [patter] = useImage(url2);
+  return [imageRef.current, statusRef.current];
+}
+
+export default useImage;

--- a/packages/epo-widget-lib/src/lib/reimg.ts
+++ b/packages/epo-widget-lib/src/lib/reimg.ts
@@ -57,7 +57,7 @@ function OutputProcessor(
     toJpeg: function (quality: number) {
       // quality should be between 0-1
       quality = quality || 1.0;
-      (function (q) {
+      ((q) => {
         this.toCanvas(function (canvas: HTMLCanvasElement) {
           var img = document.createElement("img");
           img.src = canvas.toDataURL("image/jpeg", q);

--- a/packages/epo-widget-lib/src/lib/reimg.ts
+++ b/packages/epo-widget-lib/src/lib/reimg.ts
@@ -1,0 +1,97 @@
+function OutputProcessor(encodedData: string): { [key: string]: Function };
+function OutputProcessor(
+  encodedData: string,
+  svgElement: SVGElement
+): { [key: string]: Function };
+function OutputProcessor(
+  encodedData: string,
+  svgElement?: SVGElement
+): { [key: string]: Function } {
+  const isPng = function () {
+    return encodedData.indexOf("data:image/png") === 0;
+  };
+
+  const downloadImage = function (data: string, filename: string) {
+    var a = document.createElement("a");
+    a.href = data;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+  };
+
+  return {
+    toBase64: function () {
+      return encodedData;
+    },
+    toImg: function () {
+      const imgElement = document.createElement("img");
+      imgElement.src = encodedData;
+      return imgElement;
+    },
+    toCanvas: function (callback: (canvas: HTMLCanvasElement) => void) {
+      const canvas = document.createElement("canvas");
+      const boundedRect = svgElement?.getBoundingClientRect();
+      canvas.width = boundedRect?.width || 0;
+      canvas.height = boundedRect?.height || 0;
+      const canvasCtx = canvas.getContext("2d");
+
+      var img = this.toImg();
+      img.onload = function () {
+        canvasCtx?.drawImage(img, 0, 0);
+        callback(canvas);
+      };
+    },
+    toPng: function () {
+      if (isPng()) {
+        var img = document.createElement("img");
+        img.src = encodedData;
+        return img;
+      }
+
+      this.toCanvas(function (canvas: HTMLCanvasElement) {
+        var img = document.createElement("img");
+        img.src = canvas.toDataURL();
+        return img;
+      });
+    },
+    toJpeg: function (quality: number) {
+      // quality should be between 0-1
+      quality = quality || 1.0;
+      (function (q) {
+        this.toCanvas(function (canvas: HTMLCanvasElement) {
+          var img = document.createElement("img");
+          img.src = canvas.toDataURL("image/jpeg", q);
+          return img;
+        });
+      })(quality);
+    },
+    downloadPng: function (filename: string) {
+      filename = filename || "image.png";
+      if (isPng()) {
+        // it's a canvas already
+        downloadImage(encodedData, filename);
+        return;
+      }
+
+      // convert to canvas first
+      this.toCanvas(function (canvas: HTMLCanvasElement) {
+        downloadImage(canvas.toDataURL(), filename);
+      });
+    },
+  };
+}
+
+function fromSvg(svgElement: SVGElement) {
+  const svgString = new XMLSerializer().serializeToString(svgElement);
+  return OutputProcessor(
+    "data:image/svg+xml;base64," + btoa(svgString),
+    svgElement
+  );
+}
+
+function fromCanvas(canvasElement: HTMLCanvasElement) {
+  const dataUrl = canvasElement.toDataURL();
+  return OutputProcessor(dataUrl);
+}
+
+export { fromSvg, fromCanvas };

--- a/packages/epo-widget-lib/src/widgets/ColorTool/Actions/Export/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/Actions/Export/index.tsx
@@ -1,0 +1,58 @@
+import { FunctionComponent, PropsWithChildren, useCallback } from "react";
+import Button from "@rubin-epo/epo-react-lib/Button";
+import { fromCanvas } from "@/lib/reimg";
+import { ImageFilter } from "../../ColorTool";
+
+interface ExportProps {
+  images?: HTMLCollection;
+  filename: string;
+  filters: ImageFilter[];
+  width: number;
+  height: number;
+  isDisabled: boolean;
+}
+
+const Export: FunctionComponent<PropsWithChildren<ExportProps>> = ({
+  images,
+  filters,
+  filename,
+  width,
+  height,
+  children,
+  isDisabled,
+}) => {
+  const handleExport = useCallback(() => {
+    const composite = document.createElement("canvas");
+    const ctx = composite.getContext("2d");
+
+    if (images && ctx) {
+      ctx.canvas.width = width;
+      ctx.canvas.height = height;
+      ctx.globalCompositeOperation = "screen";
+
+      Array.from<HTMLCanvasElement>(images as any).forEach((child, i) => {
+        if (filters[i].active) {
+          ctx.drawImage(child, 0, 0, width, height);
+        }
+      });
+    }
+
+    fromCanvas(composite).downloadPng(filename);
+  }, [images, filters]);
+
+  return (
+    <Button
+      disabled={isDisabled}
+      style={{ "--button-text-align": "left" }}
+      icon="ArrowUpFromBracket"
+      onClick={handleExport}
+      isBlock
+    >
+      {children}
+    </Button>
+  );
+};
+
+Export.displayName = "Widgets.ColorTool.Reset";
+
+export default Export;

--- a/packages/epo-widget-lib/src/widgets/ColorTool/Actions/Reset/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/Actions/Reset/index.tsx
@@ -1,0 +1,55 @@
+import { FunctionComponent, PropsWithChildren } from "react";
+import Button from "@rubin-epo/epo-react-lib/Button";
+import { AstroObject, ImageFilter } from "../../ColorTool";
+import { getBrightnessValue } from "../../utilities";
+
+interface ResetProps {
+  isDisabled: boolean;
+  selectedData: AstroObject;
+  onResetCallback: (data: AstroObject) => void;
+}
+
+const resetFilters = (filters: ImageFilter[]): ImageFilter[] =>
+  filters.map((filter) => {
+    const { defaultValue, min, max } = filter;
+    const value = defaultValue || 1;
+
+    return {
+      ...filter,
+      active: false,
+      color: "",
+      brightness: getBrightnessValue(min, max, value),
+      value,
+    };
+  });
+
+const Reset: FunctionComponent<PropsWithChildren<ResetProps>> = ({
+  isDisabled,
+  selectedData,
+  onResetCallback,
+  children,
+}) => {
+  const { filters } = selectedData;
+
+  return (
+    <Button
+      style={{ "--button-text-align": "left" }}
+      disabled={isDisabled}
+      icon="RotateLeftWithCenter"
+      onClick={() =>
+        onResetCallback &&
+        onResetCallback({
+          ...selectedData,
+          filters: resetFilters(filters),
+        })
+      }
+      isBlock
+    >
+      {children}
+    </Button>
+  );
+};
+
+Reset.displayName = "Widgets.ColorTool.Reset";
+
+export default Reset;

--- a/packages/epo-widget-lib/src/widgets/ColorTool/Actions/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/Actions/index.tsx
@@ -1,0 +1,74 @@
+import { FunctionComponent } from "react";
+import { AstroObject, ColorToolAction } from "../ColorTool";
+import Reset from "./Reset";
+import Export from "./Export";
+import * as Styled from "./styles";
+import { useTranslation } from "react-i18next";
+import { areActionsActive } from "../utilities";
+
+interface ActionsProps {
+  actions: Array<ColorToolAction>;
+  isDisabled: boolean;
+  selectedData: AstroObject;
+  images: HTMLCollection | undefined;
+  width: number;
+  height: number;
+  selectionCallback: (data: AstroObject) => void;
+}
+
+const Actions: FunctionComponent<ActionsProps> = ({
+  actions,
+  isDisabled,
+  width,
+  height,
+  selectedData,
+  selectionCallback,
+  images,
+}) => {
+  const { t } = useTranslation();
+  const { filters, name: filename } = selectedData;
+
+  const actionsDisabled = isDisabled || !areActionsActive(selectedData);
+
+  return (
+    <Styled.Actions>
+      {actions.map((action, i) => {
+        switch (action) {
+          case "reset":
+            return (
+              <Reset
+                key={i}
+                isDisabled={actionsDisabled}
+                {...{ selectedData }}
+                onResetCallback={(data) =>
+                  selectionCallback && selectionCallback(data)
+                }
+              >
+                {t("colorTool.actions.reset")}
+              </Reset>
+            );
+          case "export":
+            return (
+              <Export
+                key={i}
+                isDisabled={actionsDisabled}
+                {...{ filters, width, height, images, filename }}
+              >
+                Export
+              </Export>
+            );
+
+          case "save":
+            return null;
+
+          default:
+            return null;
+        }
+      })}
+    </Styled.Actions>
+  );
+};
+
+Actions.displayName = "Widgets.ColorTool.Actions";
+
+export default Actions;

--- a/packages/epo-widget-lib/src/widgets/ColorTool/Actions/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/Actions/styles.ts
@@ -2,6 +2,6 @@ import styled from "styled-components";
 
 export const Actions = styled.div`
   display: flex;
-  gap: var(--PADDING_SMALL, 20px);
+  gap: var(--color-tool-padding, var(--PADDING_SMALL, 20px));
   grid-area: actions;
 `;

--- a/packages/epo-widget-lib/src/widgets/ColorTool/Actions/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/Actions/styles.ts
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const Actions = styled.div`
+  display: flex;
+  gap: var(--PADDING_SMALL, 20px);
+  grid-area: actions;
+`;

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.stories.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.stories.tsx
@@ -28,33 +28,6 @@ const meta: Meta<typeof ColorTool> = {
         },
       },
     },
-    hideImage: {
-      control: "boolean",
-      description: "Hides the composited image.",
-      table: {
-        type: {
-          summary: "boolean",
-        },
-        category: "Display",
-        defaultValue: {
-          summary: false,
-        },
-      },
-    },
-    hideSubtitle: {
-      control: "boolean",
-      description:
-        "Hides the subtitle showing the selected object and category.",
-      table: {
-        type: {
-          summary: "boolean",
-        },
-        category: "Display",
-        defaultValue: {
-          summary: false,
-        },
-      },
-    },
     isDisabled: {
       control: "boolean",
       description: "Disables controls for the widget.",
@@ -168,6 +141,11 @@ Primary.args = {
   data: singleData,
   selectedData: singleData[0].objects[0],
   colorOptions,
+  config: {
+    actions: ["export", "reset"],
+    width: 600,
+    height: 600,
+  },
 };
 
 const objectOptions: Option[] = [];
@@ -188,6 +166,11 @@ MultipleImages.args = {
   objectOptions,
   selectedData: multiData[0].objects[0],
   colorOptions: multiSpectralOptions,
+  config: {
+    actions: ["export", "reset"],
+    width: 600,
+    height: 600,
+  },
 };
 
 export const DisplayOnly: StoryFn<typeof ColorTool> = Template.bind({});

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.test.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.test.tsx
@@ -11,7 +11,7 @@ import {
   colorOptions,
   multiSpectralOptions,
 } from "./__mocks__";
-import { Option } from "@rubin-epo/epo-react-lib/Select";
+import { ListboxOption } from "@rubin-epo/epo-react-lib/SelectListbox";
 import ColorTool from ".";
 import { getCategoryName } from "./utilities";
 
@@ -22,14 +22,13 @@ const props = {
   selectionCallback: jest.fn(),
 };
 
-const objectOptions: Option[] = [];
+const objectOptions: ListboxOption[] = [];
 
 multiData.forEach((category) => {
   category.objects.forEach((object) => {
     objectOptions.push({
       label: `${category.type}: ${object.name}`,
       value: object.name,
-      optionGroup: category.type,
     });
   });
 });
@@ -48,26 +47,9 @@ describe("ColorTool", () => {
       render(<ColorTool {...multiProps} />);
     });
     const descriptions = screen.getAllByRole("definition");
-    const select = screen.getByDisplayValue(objectOptions[0].label);
-    expect(descriptions.length).toBe(2);
+    const select = document.getElementById("astroObjectSelector");
+    expect(descriptions.length).toBe(1);
     expect(select).toBeInTheDocument();
-  });
-  it(`should change the selected object using the dropdown`, async () => {
-    await act(async () => {
-      render(<ColorTool {...multiProps} />);
-    });
-    const { name } = multiProps.selectedData;
-    const initialType = getCategoryName(multiProps.data, name) || "";
-
-    const select = screen.getByDisplayValue(objectOptions[0].label);
-    const type = screen.getByText(initialType);
-
-    fireEvent.change(select, { target: { value: objectOptions[1].value } });
-
-    waitFor(() => {
-      expect(multiProps.selectionCallback).toBeCalled();
-      expect(type.textContent).not.toBe(initialType);
-    });
   });
   it(`should disable controls when isDisabled set`, async () => {
     await act(async () => {
@@ -88,19 +70,14 @@ describe("ColorTool", () => {
       render(<ColorTool {...{ ...multiProps, isDisplayOnly: true }} />);
     });
 
-    expect(screen.queryAllByRole("combobox").length).toBe(0);
+    expect(screen.queryAllByRole("combobox").length).toBe(1);
     expect(screen.queryAllByRole("button").length).toBe(0);
-  });
-  it(`should hide image when hideImage set`, async () => {
-    await act(async () => {
-      render(<ColorTool {...{ ...multiProps, hideImage: true }} />);
-    });
-
-    expect(screen.queryAllByRole("img").length).toBe(0);
   });
   it(`should hide subtitle when hideSubtitle set`, async () => {
     await act(async () => {
-      render(<ColorTool {...{ ...multiProps, hideSubtitle: true }} />);
+      render(
+        <ColorTool {...{ ...multiProps, config: { hideSubtitle: true } }} />
+      );
     });
 
     const { name } = multiProps.selectedData;

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.test.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.test.tsx
@@ -70,7 +70,7 @@ describe("ColorTool", () => {
       render(<ColorTool {...{ ...multiProps, isDisplayOnly: true }} />);
     });
 
-    expect(screen.queryAllByRole("combobox").length).toBe(1);
+    expect(screen.queryAllByRole("combobox").length).toBe(0);
     expect(screen.queryAllByRole("button").length).toBe(0);
   });
   it(`should hide subtitle when hideSubtitle set`, async () => {

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.tsx
@@ -78,6 +78,7 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
   };
 
   const imageRef = useRef<HTMLDivElement>(null);
+  const { t } = useTranslation();
 
   const handleFilterChange = useCallback(
     (updatedFilter: ImageFilter) => {
@@ -113,25 +114,33 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
     [selectionCallback, data]
   );
 
-  const hasMultipleDatasets = data.length > 1;
+  const { filters, name: selectedObjectName } = selectedData;
   const { actions, width, height, hideSubtitle } = {
     ...defaultConfig,
     ...config,
   };
-  const { t } = useTranslation();
+
+  if (isDisplayOnly) {
+    return (
+      <ImageComposite
+        ref={imageRef}
+        {...{ filters, width, height, selectedObjectName }}
+      />
+    );
+  }
+
+  const hasMultipleDatasets = data.length > 1;
   const selectPlaceholder = t("colorTool.actions.select_an_object");
-  const { filters, name: selectedObjectName } = selectedData;
 
   return (
     <Styled.WidgetContainer>
       <Styled.WidgetLayout
         style={{
-          "--controls-row": isDisplayOnly ? "'image image'" : undefined,
           "--image-width": typeof width === "number" ? `${width}px` : width,
           "--image-height": typeof height === "number" ? `${height}px` : height,
         }}
       >
-        {selectedObjectName && (isDisplayOnly || hasMultipleDatasets) && (
+        {selectedObjectName && hasMultipleDatasets && (
           <Styled.Title>
             {!hideSubtitle && (
               <>
@@ -142,40 +151,38 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
             {}
           </Styled.Title>
         )}
-        {!isDisplayOnly && (
-          <Styled.ControlsContainer>
-            {filters && (
-              <>
-                <Styled.ToolsHeader id="filterLabel">
-                  {t("colorTool.labels.filter")}
-                </Styled.ToolsHeader>
-                <Styled.ToolsHeader id="colorLabel">
-                  {t("colorTool.labels.color")}
-                </Styled.ToolsHeader>
-                <Styled.ToolsHeader id="intensityLabel">
-                  {t("colorTool.labels.color_intensity")}
-                </Styled.ToolsHeader>
-              </>
-            )}
-            {filters &&
-              filters.map((imageFilter) => {
-                const { label, isDisabled: isFilterDisabled } = imageFilter;
+        <Styled.ControlsContainer>
+          {filters && (
+            <>
+              <Styled.ToolsHeader id="filterLabel">
+                {t("colorTool.labels.filter")}
+              </Styled.ToolsHeader>
+              <Styled.ToolsHeader id="colorLabel">
+                {t("colorTool.labels.color")}
+              </Styled.ToolsHeader>
+              <Styled.ToolsHeader id="intensityLabel">
+                {t("colorTool.labels.color_intensity")}
+              </Styled.ToolsHeader>
+            </>
+          )}
+          {filters &&
+            filters.map((imageFilter) => {
+              const { label, isDisabled: isFilterDisabled } = imageFilter;
 
-                return (
-                  <FilterControls
-                    key={`filter-${label}`}
-                    filter={imageFilter}
-                    isDisabled={isDisabled || isFilterDisabled}
-                    colorOptions={colorOptions}
-                    onChangeFilterCallback={handleFilterChange}
-                    buttonLabelledById="filterLabel"
-                    selectLabelledById="colorLabel"
-                    sliderLabelledById="intensityLabel"
-                  />
-                );
-              })}
-          </Styled.ControlsContainer>
-        )}
+              return (
+                <FilterControls
+                  key={`filter-${label}`}
+                  filter={imageFilter}
+                  isDisabled={isDisabled || isFilterDisabled}
+                  colorOptions={colorOptions}
+                  onChangeFilterCallback={handleFilterChange}
+                  buttonLabelledById="filterLabel"
+                  selectLabelledById="colorLabel"
+                  sliderLabelledById="intensityLabel"
+                />
+              );
+            })}
+        </Styled.ControlsContainer>
         <ImageComposite
           ref={imageRef}
           {...{ filters, width, height, selectedObjectName }}
@@ -195,19 +202,17 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
             </Styled.SelectionContainer>
           )}
         </ImageComposite>
-        {!isDisplayOnly && (
-          <Actions
-            actions={actions as ColorToolAction[]}
-            images={imageRef.current?.getElementsByTagName("canvas")}
-            {...{
-              selectedData,
-              width,
-              height,
-              isDisabled,
-              selectionCallback,
-            }}
-          />
-        )}
+        <Actions
+          actions={actions as ColorToolAction[]}
+          images={imageRef.current?.getElementsByTagName("canvas")}
+          {...{
+            selectedData,
+            width,
+            height,
+            isDisabled,
+            selectionCallback,
+          }}
+        />
       </Styled.WidgetLayout>
     </Styled.WidgetContainer>
   );

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.tsx
@@ -53,6 +53,7 @@ interface ColorToolProps {
   isDisabled?: boolean;
   isDisplayOnly?: boolean;
   config?: ColorToolConfig;
+  className?: string;
 }
 
 const ColorTool: FunctionComponent<ColorToolProps> = ({
@@ -63,6 +64,7 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
   selectionCallback,
   isDisabled = false,
   isDisplayOnly = false,
+  className,
   config = {
     actions: ["reset"],
     width: 600,
@@ -80,40 +82,6 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
   const imageRef = useRef<HTMLDivElement>(null);
   const { t } = useTranslation();
 
-  const handleFilterChange = useCallback(
-    (updatedFilter: ImageFilter) => {
-      const { label } = updatedFilter;
-      const { filters } = selectedData;
-      const updatedFilters = filters.map((f) =>
-        f.label === label ? updatedFilter : f
-      );
-
-      return (
-        selectionCallback &&
-        selectionCallback({
-          ...selectedData,
-          filters: updatedFilters,
-        })
-      );
-    },
-    [selectedData, selectionCallback]
-  );
-
-  const handleObjectSelection = useCallback(
-    (value: string | null) => {
-      if (value === null) return;
-
-      return (
-        selectionCallback &&
-        selectionCallback({
-          name: value,
-          filters: getDataFiltersByName(data, value),
-        })
-      );
-    },
-    [selectionCallback, data]
-  );
-
   const { filters, name: selectedObjectName } = selectedData;
   const { actions, width, height, hideSubtitle } = {
     ...defaultConfig,
@@ -124,16 +92,44 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
     return (
       <ImageComposite
         ref={imageRef}
-        {...{ filters, width, height, selectedObjectName }}
+        {...{ filters, width, height, selectedObjectName, className }}
       />
     );
   }
+
+  const handleFilterChange = (updatedFilter: ImageFilter) => {
+    const { label } = updatedFilter;
+    const { filters } = selectedData;
+    const updatedFilters = filters.map((f) =>
+      f.label === label ? updatedFilter : f
+    );
+
+    return (
+      selectionCallback &&
+      selectionCallback({
+        ...selectedData,
+        filters: updatedFilters,
+      })
+    );
+  };
+
+  const handleObjectSelection = (value: string | null) => {
+    if (value === null) return;
+
+    return (
+      selectionCallback &&
+      selectionCallback({
+        name: value,
+        filters: getDataFiltersByName(data, value),
+      })
+    );
+  };
 
   const hasMultipleDatasets = data.length > 1;
   const selectPlaceholder = t("colorTool.actions.select_an_object");
 
   return (
-    <Styled.WidgetContainer>
+    <Styled.WidgetContainer className={className}>
       <Styled.WidgetLayout
         style={{
           "--image-width": typeof width === "number" ? `${width}px` : width,
@@ -166,15 +162,14 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
             </>
           )}
           {filters &&
-            filters.map((imageFilter) => {
-              const { label, isDisabled: isFilterDisabled } = imageFilter;
+            filters.map((filter) => {
+              const { label, isDisabled: isFilterDisabled } = filter;
 
               return (
                 <FilterControls
+                  {...{ filter, colorOptions }}
                   key={`filter-${label}`}
-                  filter={imageFilter}
                   isDisabled={isDisabled || isFilterDisabled}
-                  colorOptions={colorOptions}
                   onChangeFilterCallback={handleFilterChange}
                   buttonLabelledById="filterLabel"
                   selectLabelledById="colorLabel"

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.tsx
@@ -16,7 +16,7 @@ export interface ImageFilter {
   active: boolean;
   image: string;
   isDisabled: boolean;
-  value?: number;
+  value: number;
   defaultValue?: number;
   min: number;
   max: number;
@@ -36,11 +36,11 @@ export interface AstroCategory {
 export type ColorToolAction = "reset" | "export" | "save";
 
 interface ColorToolConfig {
-  actions: Array<ColorToolAction>;
+  actions?: Array<ColorToolAction>;
   /** pixel width of the images in the tool */
-  width: number;
+  width?: number;
   /** pixel height of the images in the tool */
-  height: number;
+  height?: number;
   hideSubtitle?: boolean;
 }
 
@@ -70,6 +70,13 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
     hideSubtitle: false,
   },
 }) => {
+  const defaultConfig = {
+    actions: ["reset"],
+    width: 600,
+    height: 600,
+    hideSubtitle: false,
+  };
+
   const imageRef = useRef<HTMLDivElement>(null);
 
   const handleFilterChange = useCallback(
@@ -107,7 +114,10 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
   );
 
   const hasMultipleDatasets = data.length > 1;
-  const { actions, width, height, hideSubtitle } = config;
+  const { actions, width, height, hideSubtitle } = {
+    ...defaultConfig,
+    ...config,
+  };
   const { t } = useTranslation();
   const selectPlaceholder = t("colorTool.actions.select_an_object");
   const { filters, name: selectedObjectName } = selectedData;
@@ -187,9 +197,9 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
         </ImageComposite>
         {!isDisplayOnly && (
           <Actions
+            actions={actions as ColorToolAction[]}
             images={imageRef.current?.getElementsByTagName("canvas")}
             {...{
-              actions,
               selectedData,
               width,
               height,

--- a/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/FilterControls.test.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/FilterControls.test.tsx
@@ -40,7 +40,7 @@ describe("FilterControls", () => {
   it(`should disable controls`, () => {
     render(<FilterControls {...{ ...props, isDisabled: true }} />);
 
-    const button = screen.getByRole("button");
+    const button = screen.getByRole("checkbox");
     const select = screen.getByRole("combobox");
     const slider = screen.getByRole("slider");
 
@@ -51,7 +51,7 @@ describe("FilterControls", () => {
   it(`should call callback on modification`, () => {
     render(<FilterControls {...props} />);
 
-    const button = screen.getByRole("button");
+    const button = screen.getByRole("checkbox");
 
     fireEvent.click(button);
 

--- a/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/FilterControls.test.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/FilterControls.test.tsx
@@ -3,7 +3,7 @@ import { singleData, colorOptions } from "../__mocks__";
 import FilterControls from ".";
 import { getBrightnessValue } from "../utilities";
 
-const { value, min, max } = singleData[0].objects[0].filters[0];
+const { value = 1, min, max } = singleData[0].objects[0].filters[0];
 const props = {
   filter: {
     ...singleData[0].objects[0].filters[0],

--- a/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/FilterControls.test.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/FilterControls.test.tsx
@@ -29,11 +29,9 @@ describe("FilterControls", () => {
       </>
     );
 
-    const button = screen.getByLabelText("Button");
     const select = screen.getByLabelText("Select");
     const slider = screen.getByLabelText("Slider");
 
-    expect(button).toBeInTheDocument();
     expect(select).toBeInTheDocument();
     expect(slider).toBeInTheDocument();
   });
@@ -46,7 +44,7 @@ describe("FilterControls", () => {
 
     expect(button).toBeDisabled();
     expect(select).toBeDisabled();
-    expect(slider.parentElement).toHaveClass("disabled");
+    expect(slider).toHaveAttribute("aria-disabled", "true");
   });
   it(`should call callback on modification`, () => {
     render(<FilterControls {...props} />);

--- a/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/FilterControls.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/FilterControls.tsx
@@ -47,18 +47,17 @@ const FilterControls: FunctionComponent<FilterControlProps> = ({
   const selectPlaceholder = t("colorTool.actions.select_filter");
 
   return (
-    <>
-      <Styled.FilterLabel aria-labelledby={buttonLabelledById}>
+    <Styled.FilterContainer disabled={isDisabled}>
+      <Styled.FilterLabel>
         <Styled.HiddenCheckbox
-          disabled={isDisabled}
           checked={active}
           type="checkbox"
           onChange={handleImage}
+          aria-describedby={buttonLabelledById}
         />
         <Styled.FilterToggle as="span">{label}</Styled.FilterToggle>
       </Styled.FilterLabel>
       <SelectListbox
-        isDisabled={isDisabled}
         placeholder={selectPlaceholder}
         value={color}
         options={colorOptions}
@@ -71,11 +70,11 @@ const FilterControls: FunctionComponent<FilterControlProps> = ({
         min={1}
         max={100}
         onChangeCallback={handleBrightness}
-        isDisabled={!active}
+        isDisabled={!active || isDisabled}
         labelledbyId={sliderLabelledById}
         {...{ value, label, color }}
       />
-    </>
+    </Styled.FilterContainer>
   );
 };
 

--- a/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/FilterControls.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/FilterControls.tsx
@@ -5,7 +5,7 @@ import { FunctionComponent } from "react";
 import { ImageFilter } from "../ColorTool";
 import { getBrightnessValue } from "../utilities";
 import { useTranslation } from "react-i18next";
-import * as Styled from "../styles";
+import * as Styled from "./styles";
 
 interface FilterControlProps {
   filter: ImageFilter;
@@ -48,14 +48,15 @@ const FilterControls: FunctionComponent<FilterControlProps> = ({
 
   return (
     <>
-      <Styled.FilterToggleButton
-        disabled={isDisabled}
-        onClick={handleImage}
-        $active={active}
-        aria-labelledby={buttonLabelledById}
-      >
-        {label}
-      </Styled.FilterToggleButton>
+      <Styled.FilterLabel aria-labelledby={buttonLabelledById}>
+        <Styled.HiddenCheckbox
+          disabled={isDisabled}
+          checked={active}
+          type="checkbox"
+          onChange={handleImage}
+        />
+        <Styled.FilterToggle as="span">{label}</Styled.FilterToggle>
+      </Styled.FilterLabel>
       <SelectListbox
         isDisabled={isDisabled}
         placeholder={selectPlaceholder}

--- a/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/styles.ts
@@ -1,0 +1,68 @@
+import styled from "styled-components";
+import HorizontalSlider from "@rubin-epo/epo-react-lib/HorizontalSlider";
+import Button from "@rubin-epo/epo-react-lib/Button";
+
+export const HiddenCheckbox = styled.input`
+  position: absolute;
+  left: -999px;
+  width: 1px;
+  height: 1px;
+  top: auto;
+  overflow: hidden;
+`;
+
+export const FilterToggle = styled(Button)`
+  background-color: var(--filter-toggle-background, #f7f7f7);
+  border: 1px solid;
+  color: var(--filter-toggle-color, #6c6e6e);
+  display: flex;
+  justify-content: center;
+  border-radius: 50%;
+  font-weight: var(--FONT_WEIGHT_MEDIUM, 500);
+  font-size: 22px;
+  text-transform: lowercase;
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  user-select: none;
+`;
+
+export const FilterLabel = styled.label`
+  overflow: hidden;
+
+  input:not(:disabled) + span {
+    cursor: pointer;
+
+    &:hover {
+      outline: 2px solid #6c6e6e;
+      outline-offset: -2px;
+    }
+  }
+
+  input:not(:disabled):focus + span,
+  input:not(:disabled):focus-visible + span {
+    outline: 2px solid #6c6e6e;
+    outline-offset: -2px;
+  }
+
+  input:not(:disabled):checked + span {
+    --filter-toggle-background: var(--turquoise85, #12726c);
+    --filter-toggle-color: var(--white, #fff);
+
+    &:hover {
+      outline: 1px solid var(--white, #fff);
+      outline-offset: -3px;
+    }
+  }
+
+  input:not(:disabled):checked:focus + span,
+  input:not(:disabled):checked:focus-visible + span {
+    outline: 1px solid var(--white, #fff);
+    outline-offset: -3px;
+  }
+`;
+
+export const Slider = styled(HorizontalSlider)`
+  padding: 0;
+  width: 100%;
+`;

--- a/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/styles.ts
@@ -2,6 +2,18 @@ import styled from "styled-components";
 import HorizontalSlider from "@rubin-epo/epo-react-lib/HorizontalSlider";
 import Button from "@rubin-epo/epo-react-lib/Button";
 
+export const FilterContainer = styled.fieldset`
+  padding: 0;
+  margin: 0;
+  border: none;
+  display: grid;
+  align-items: center;
+  gap: var(--color-tool-padding, var(--PADDING_SMALL, 20px));
+  grid-template-columns: max-content minmax(100px, 1fr) minmax(100px, 2fr);
+  grid-auto-rows: max-content;
+  grid-column: 1 / -1;
+`;
+
 export const HiddenCheckbox = styled.input`
   position: absolute;
   left: -999px;

--- a/packages/epo-widget-lib/src/widgets/ColorTool/FilterImage/FilterImage.stories.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/FilterImage/FilterImage.stories.tsx
@@ -6,7 +6,7 @@ import FilterImage from ".";
 const meta: ComponentMeta<typeof FilterImage> = {
   argTypes: {
     className: argTypes.className,
-    image: {
+    url: {
       type: {
         name: "string",
         required: true,
@@ -91,8 +91,7 @@ export default meta;
 export const Primary: ComponentStoryObj<typeof FilterImage> = {
   args: {
     height: 300,
-    image:
-      "https://rubin.canto.com/direct/image/3jhaht4beh6aha6eiplkb5us6o/MlO1oSfjiMJBT25-VtnRD7B0-EI/original?content-type=image%2Fjpeg&name=Wide_View_Telescope_Mount.jpg",
+    url: "https://rubin.canto.com/direct/image/3jhaht4beh6aha6eiplkb5us6o/MlO1oSfjiMJBT25-VtnRD7B0-EI/original?content-type=image%2Fjpeg&name=Wide_View_Telescope_Mount.jpg",
     color: "#EC1C24",
   },
 };

--- a/packages/epo-widget-lib/src/widgets/ColorTool/FilterImage/FilterImage.test.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/FilterImage/FilterImage.test.tsx
@@ -1,10 +1,12 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import FilterImage from ".";
 
 const props = {
-  image: "https://via.placeholder.com/300",
+  url: "https://via.placeholder.com/300",
   width: 300,
   height: 300,
+  active: true,
+  onLoadCallback: jest.fn(),
 };
 
 describe("FilterImage", () => {
@@ -26,5 +28,14 @@ describe("FilterImage", () => {
     const img = canvas.toDataURL();
 
     expect(img).toMatchSnapshot();
+  });
+  it("should perform a callback when loading is complete", async () => {
+    await act(async () => {
+      render(<FilterImage {...props} />);
+    });
+
+    waitFor(() => {
+      expect(props.onLoadCallback).toBeCalled();
+    });
   });
 });

--- a/packages/epo-widget-lib/src/widgets/ColorTool/FilterImage/FilterImage.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/FilterImage/FilterImage.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent, HTMLAttributes, useRef } from "react";
 import useImage from "@/hooks/useImage";
+import { isStyleSupported } from "../utilities";
 import * as Styled from "../styles";
 
 export interface FilterImageProps extends HTMLAttributes<HTMLCanvasElement> {
@@ -42,7 +43,7 @@ const FilterImage: FunctionComponent<FilterImageProps> = ({
     canvasWidth: number,
     canvasHeight: number
   ) => {
-    const safeColor = color === "" || color === null ? "transparent" : color;
+    const safeColor = isStyleSupported("color", color) ? color : "transparent";
 
     ctx.fillStyle = safeColor;
     ctx.fillRect(0, 0, canvasWidth, canvasHeight);

--- a/packages/epo-widget-lib/src/widgets/ColorTool/FilterImage/FilterImage.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/FilterImage/FilterImage.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, HTMLAttributes, useRef } from "react";
-import useImage from "use-image";
+import useImage from "@/hooks/useImage";
 import * as Styled from "../styles";
 
 export interface FilterImageProps extends HTMLAttributes<HTMLCanvasElement> {
@@ -13,6 +13,7 @@ export interface FilterImageProps extends HTMLAttributes<HTMLCanvasElement> {
   filters?: {
     [key: string]: number | undefined;
   };
+  onLoadCallback?: () => void;
 }
 
 const FilterImage: FunctionComponent<FilterImageProps> = ({
@@ -25,8 +26,13 @@ const FilterImage: FunctionComponent<FilterImageProps> = ({
     brightness: 1,
   },
   active,
+  onLoadCallback,
 }) => {
-  const [image, status] = useImage(url, "anonymous");
+  const [image, status] = useImage({
+    url,
+    crossOrigin: "anonymous",
+    onLoadCallback,
+  });
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const ctx = canvasRef.current?.getContext("2d");
 
@@ -42,7 +48,9 @@ const FilterImage: FunctionComponent<FilterImageProps> = ({
     ctx.fillRect(0, 0, canvasWidth, canvasHeight);
   };
 
-  const getFilters = (filters: { [key: string]: number }): string => {
+  const getFilters = (filters: {
+    [key: string]: number | undefined;
+  }): string => {
     return Object.keys(filters).reduce((prev, key, i) => {
       return (prev += `${i > 0 ? " " : ""}${key}(${filters[key]})`);
     }, "");

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/ImageComposite.test.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/ImageComposite.test.tsx
@@ -4,6 +4,9 @@ import ImageComposite from ".";
 
 const props = {
   filters: singleData[0].objects[0].filters,
+  width: 600,
+  height: 600,
+  selectedObjectName: singleData[0].objects[0].name,
 };
 
 describe("ImageComposite", () => {
@@ -12,6 +15,6 @@ describe("ImageComposite", () => {
 
     const filters = screen.getAllByRole("img", { hidden: true });
 
-    expect(filters.length).toBe(props.filters.length + 1);
+    expect(filters.length).toBe(props.filters.length);
   });
 });

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/ImageComposite.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/ImageComposite.tsx
@@ -33,7 +33,13 @@ const ImageComposite = forwardRef<
   );
 
   return (
-    <Styled.ImageContainer ref={ref}>
+    <Styled.ImageContainer
+      ref={ref}
+      style={{
+        "--image-width": typeof width === "number" ? `${width}px` : width,
+        "--image-height": typeof height === "number" ? `${height}px` : height,
+      }}
+    >
       {!imagesLoaded && isAnyActive && <CircularLoader isVisible={isLoading} />}
       <Styled.LoadingContainer
         style={{ "--loading-opacity": isLoading ? 0 : 1 }}

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/ImageComposite.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/ImageComposite.tsx
@@ -1,41 +1,45 @@
-import { FunctionComponent } from "react";
+import { forwardRef, PropsWithChildren } from "react";
 import { ImageFilter } from "../ColorTool";
-import { isFilterActive } from "../utilities";
+import FilterImage from "../FilterImage";
 import * as Styled from "../styles";
 
 interface ImageCompositeProps {
   filters: ImageFilter[];
+  width: number;
+  height: number;
 }
 
-const ImageComposite: FunctionComponent<ImageCompositeProps> = ({
-  filters,
-}) => {
+const ImageComposite = forwardRef<
+  HTMLDivElement,
+  PropsWithChildren<ImageCompositeProps>
+>(({ filters, width, height, children }, ref) => {
   return (
-    <Styled.ImageContainer>
-      <Styled.BackgroundImage
-        alt=""
-        src="data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs="
-        $filtersActive={isFilterActive(filters)}
-      />
+    <Styled.ImageContainer ref={ref}>
       {filters &&
         filters.map((filter) => {
           const { label, image, color, brightness, active } = filter;
 
           return (
-            <Styled.FilteredImage
+            <FilterImage
               key={`filter-${label}`}
               {...{
-                image,
+                url: image,
                 color,
-                brightness,
                 active,
+                width,
+                height,
+                filters: {
+                  brightness,
+                  contrast: 1.3,
+                },
               }}
             />
           );
         })}
+      {children}
     </Styled.ImageContainer>
   );
-};
+});
 
 ImageComposite.displayName = "Widgets.ColorTool.ImageComposite";
 

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/ImageComposite.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/ImageComposite.tsx
@@ -10,67 +10,75 @@ interface ImageCompositeProps {
   width: number;
   height: number;
   selectedObjectName: string;
+  className?: string;
 }
 
 const ImageComposite = forwardRef<
   HTMLDivElement,
   PropsWithChildren<ImageCompositeProps>
->(({ filters, width, height, selectedObjectName, children }, ref) => {
-  const [prevObject, setPrevObject] = useState(selectedObjectName);
-  const [imagesLoaded, setImagesLoaded] = useState(0);
-  const isAnyActive = isFilterActive(filters);
-  const enabledFilters = filters.filter((f) => !f.isDisabled).length;
-  const isLoading = imagesLoaded !== enabledFilters;
+>(
+  (
+    { filters, width, height, selectedObjectName, className, children },
+    ref
+  ) => {
+    const [prevObject, setPrevObject] = useState(selectedObjectName);
+    const [imagesLoaded, setImagesLoaded] = useState(0);
+    const isAnyActive = isFilterActive(filters);
+    const enabledFilters = filters.filter((f) => !f.isDisabled).length;
+    const isLoading = imagesLoaded !== enabledFilters;
 
-  if (selectedObjectName !== prevObject) {
-    setPrevObject(selectedObjectName);
-    setImagesLoaded(0);
-  }
+    if (selectedObjectName !== prevObject) {
+      setPrevObject(selectedObjectName);
+      setImagesLoaded(0);
+    }
 
-  const onLoadCallback = useCallback(
-    () => setImagesLoaded((count) => count + 1),
-    [imagesLoaded, filters]
-  );
+    const onLoadCallback = useCallback(
+      () => setImagesLoaded((count) => count + 1),
+      [imagesLoaded, filters]
+    );
 
-  return (
-    <Styled.ImageContainer
-      ref={ref}
-      style={{
-        "--image-width": typeof width === "number" ? `${width}px` : width,
-        "--image-height": typeof height === "number" ? `${height}px` : height,
-      }}
-    >
-      {!imagesLoaded && isAnyActive && <CircularLoader isVisible={isLoading} />}
-      <Styled.LoadingContainer
-        style={{ "--loading-opacity": isLoading ? 0 : 1 }}
+    return (
+      <Styled.ImageContainer
+        className={className}
+        ref={ref}
+        style={{
+          "--image-container-opacity": imagesLoaded && isAnyActive ? 1 : 0.1,
+        }}
       >
-        {filters &&
-          filters.map((filter) => {
-            const { label, image, color, brightness, active } = filter;
+        {!imagesLoaded && isAnyActive && (
+          <CircularLoader isVisible={isLoading} />
+        )}
+        <Styled.LoadingContainer
+          style={{ "--loading-opacity": isLoading ? 0 : 1 }}
+        >
+          {filters &&
+            filters.map((filter) => {
+              const { label, image, color, brightness, active } = filter;
 
-            return (
-              <FilterImage
-                key={`filter-${label}`}
-                {...{
-                  url: image,
-                  color,
-                  active,
-                  width,
-                  height,
-                  filters: {
-                    brightness,
-                    contrast: 1.3,
-                  },
-                  onLoadCallback,
-                }}
-              />
-            );
-          })}
-      </Styled.LoadingContainer>
-      {children}
-    </Styled.ImageContainer>
-  );
-});
+              return (
+                <FilterImage
+                  key={`filter-${label}`}
+                  {...{
+                    url: image,
+                    color,
+                    active,
+                    width,
+                    height,
+                    filters: {
+                      brightness,
+                      contrast: 1.3,
+                    },
+                    onLoadCallback,
+                  }}
+                />
+              );
+            })}
+        </Styled.LoadingContainer>
+        {children}
+      </Styled.ImageContainer>
+    );
+  }
+);
 
 ImageComposite.displayName = "Widgets.ColorTool.ImageComposite";
 

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/ImageComposite.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/ImageComposite.tsx
@@ -1,41 +1,66 @@
-import { forwardRef, PropsWithChildren } from "react";
+import { forwardRef, PropsWithChildren, useCallback, useState } from "react";
+import CircularLoader from "@rubin-epo/epo-react-lib/CircularLoader";
 import { ImageFilter } from "../ColorTool";
 import FilterImage from "../FilterImage";
-import * as Styled from "../styles";
+import * as Styled from "./styles";
+import { isFilterActive } from "../utilities";
 
 interface ImageCompositeProps {
   filters: ImageFilter[];
   width: number;
   height: number;
+  selectedObjectName: string;
 }
 
 const ImageComposite = forwardRef<
   HTMLDivElement,
   PropsWithChildren<ImageCompositeProps>
->(({ filters, width, height, children }, ref) => {
+>(({ filters, width, height, selectedObjectName, children }, ref) => {
+  const [prevObject, setPrevObject] = useState(selectedObjectName);
+  const [imagesLoaded, setImagesLoaded] = useState(0);
+  const isAnyActive = isFilterActive(filters);
+  const enabledFilters = filters.filter((f) => !f.isDisabled).length;
+  const isLoading = imagesLoaded !== enabledFilters;
+
+  if (selectedObjectName !== prevObject) {
+    setPrevObject(selectedObjectName);
+    setImagesLoaded(0);
+  }
+
+  const onLoadCallback = useCallback(
+    () => setImagesLoaded((count) => count + 1),
+    [imagesLoaded, filters]
+  );
+
   return (
     <Styled.ImageContainer ref={ref}>
-      {filters &&
-        filters.map((filter) => {
-          const { label, image, color, brightness, active } = filter;
+      {!imagesLoaded && isAnyActive && <CircularLoader isVisible={isLoading} />}
+      <Styled.LoadingContainer
+        style={{ "--loading-opacity": isLoading ? 0 : 1 }}
+      >
+        {filters &&
+          filters.map((filter) => {
+            const { label, image, color, brightness, active } = filter;
 
-          return (
-            <FilterImage
-              key={`filter-${label}`}
-              {...{
-                url: image,
-                color,
-                active,
-                width,
-                height,
-                filters: {
-                  brightness,
-                  contrast: 1.3,
-                },
-              }}
-            />
-          );
-        })}
+            return (
+              <FilterImage
+                key={`filter-${label}`}
+                {...{
+                  url: image,
+                  color,
+                  active,
+                  width,
+                  height,
+                  filters: {
+                    brightness,
+                    contrast: 1.3,
+                  },
+                  onLoadCallback,
+                }}
+              />
+            );
+          })}
+      </Styled.LoadingContainer>
       {children}
     </Styled.ImageContainer>
   );

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/styles.ts
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+export const ImageContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  aspect-ratio: 1 / 1;
+  grid-area: image;
+  background-color: rgba(0, 0, 0, 0.1);
+`;
+
+export const LoadingContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  opacity: var(--loading-opacity, 0);
+  transition: opacity ease var(--DURATION_SLOW, 0.4s);
+  position: absolute;
+  top: 0;
+  left: 0;
+`;

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/styles.ts
@@ -7,9 +7,8 @@ export const ImageContainer = styled.div`
   position: relative;
   aspect-ratio: 1 / 1;
   grid-area: image;
-  background-color: rgba(0, 0, 0, 0.1);
-  max-width: var(--image-width);
-  max-height: var(--image-height);
+  background-color: rgba(0, 0, 0, var(--image-container-opacity, 0.1));
+  transition: background-color ease var(--DURATION, 0.2s);
 `;
 
 export const LoadingContainer = styled.div`

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ImageComposite/styles.ts
@@ -8,6 +8,8 @@ export const ImageContainer = styled.div`
   aspect-ratio: 1 / 1;
   grid-area: image;
   background-color: rgba(0, 0, 0, 0.1);
+  max-width: var(--image-width);
+  max-height: var(--image-height);
 `;
 
 export const LoadingContainer = styled.div`

--- a/packages/epo-widget-lib/src/widgets/ColorTool/__mocks__/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/__mocks__/index.tsx
@@ -149,8 +149,6 @@ export const multiData: AstroCategory[] = [
     objects: [
       {
         name: "M51",
-        caption:
-          "Image credit:  T.A. Rector (University of Alaska Anchorage) and CTIO/NOAO/NSF and Subaru HSC Data Release 1",
         filters: [
           {
             label: "u",
@@ -871,6 +869,7 @@ export const singleData: AstroCategory[] = [
           {
             label: "R",
             color: "",
+            defaultValue: 10,
             value: 1,
             min: 0.5,
             max: 1.5,
@@ -882,6 +881,7 @@ export const singleData: AstroCategory[] = [
           {
             label: "G",
             color: "",
+            defaultValue: 20,
             value: 1,
             min: 0.5,
             max: 1.5,
@@ -893,6 +893,7 @@ export const singleData: AstroCategory[] = [
           {
             label: "B",
             color: "",
+            defaultValue: 30,
             value: 1,
             min: 0.5,
             max: 1.5,

--- a/packages/epo-widget-lib/src/widgets/ColorTool/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/styles.ts
@@ -53,7 +53,7 @@ export const ControlsContainer = styled.div`
   grid-template-columns: max-content minmax(100px, 1fr) minmax(100px, 2fr);
   grid-auto-rows: max-content;
   grid-area: controls;
-  gap: 10px;
+  gap: var(--color-tool-padding, var(--PADDING_SMALL, 20px));
   align-items: center;
 `;
 

--- a/packages/epo-widget-lib/src/widgets/ColorTool/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/styles.ts
@@ -2,34 +2,29 @@ import styled, { css } from "styled-components";
 import Button from "@rubin-epo/epo-react-lib/Button";
 import HorizontalSlider from "@rubin-epo/epo-react-lib/HorizontalSlider";
 import { token } from "@rubin-epo/epo-react-lib/styles";
-import FilterImage from "./FilterImage";
 
 export const WidgetContainer = styled.section`
   container: colorTool / inline-size;
 `;
 
-const breakSize = token("BREAK_LARGE_TABLET_MIN");
+const breakSize = token("BREAK_DESKTOP_SMALL");
 
 export const WidgetLayout = styled.div`
-  --widget-areas: "title" "subtitle" "image" "caption" "controls" "reset";
+  --widget-areas: "image" "controls" "actions" "title";
   --controls-row: "controls image";
   display: grid;
   gap: var(--PADDING_SMALL, 20px);
   grid-template-areas: var(--widget-areas);
+  grid-template-columns: 1fr;
 
   @container colorTool (min-width: ${breakSize}) {
-    --widget-areas: "title title" "subtitle subtitle" var(--controls-row)
-      "reset reset" "caption caption";
+    --widget-areas: var(--controls-row) "actions actions" "title title";
+    grid-template-columns: 1fr var(--image-width, 1fr);
   }
 `;
 
-export const Title = styled.h2`
+export const Title = styled.dl`
   grid-area: title;
-  margin: 0;
-`;
-
-export const Subtitle = styled.dl`
-  grid-area: subtitle;
   margin: 0;
   font-size: 18px;
   font-weight: var(--FONT_WEIGHT_NORMAL, 400);
@@ -76,18 +71,7 @@ export const ImageContainer = styled.div`
   background-color: rgba(0, 0, 0, 0.1);
 `;
 
-export const BackgroundImage = styled.img<{ $filtersActive: boolean }>`
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  display: ${({ $filtersActive }) => ($filtersActive ? "block" : "none")};
-  width: 100%;
-  height: 100%;
-`;
-
-export const FilteredImage = styled(FilterImage)<{ active: boolean }>`
+export const Image = styled.canvas`
   user-select: none;
   position: absolute;
   top: 0;
@@ -97,38 +81,17 @@ export const FilteredImage = styled(FilterImage)<{ active: boolean }>`
   width: 100%;
   height: 100%;
   mix-blend-mode: screen;
-
-  ${({ active }) =>
-    active
-      ? css`
-          visibility: visible;
-          opacity: 1;
-        `
-      : css`
-          visibility: hidden;
-          opacity: 0;
-        `}
+  opacity: var(--image-opacity, 0);
+  visibility: var(--image-visibility, hidden);
 `;
 
 export const SelectionContainer = styled.div`
-  grid-column: span 3;
+  margin-block-start: var(--PADDING_SMALL, 20px);
+  margin-inline: var(--PADDING_SMALL, 20px);
 `;
 
 export const ToolsHeader = styled.div`
   font-weight: var(--FONT_WEIGHT_BOLD, 600);
-`;
-
-export const Caption = styled.footer`
-  grid-area: caption;
-`;
-
-export const ResetButton = styled(Button)`
-  grid-area: reset;
-  text-align: left;
-
-  span {
-    text-align: left;
-  }
 `;
 
 export const FilterToggleButton = styled(Button)<{ $active: boolean }>`

--- a/packages/epo-widget-lib/src/widgets/ColorTool/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/styles.ts
@@ -64,13 +64,6 @@ export const Slider = styled(HorizontalSlider)`
   width: 100%;
 `;
 
-export const ImageContainer = styled.div`
-  position: relative;
-  aspect-ratio: 1 / 1;
-  grid-area: image;
-  background-color: rgba(0, 0, 0, 0.1);
-`;
-
 export const Image = styled.canvas`
   user-select: none;
   position: absolute;
@@ -86,8 +79,10 @@ export const Image = styled.canvas`
 `;
 
 export const SelectionContainer = styled.div`
-  margin-block-start: var(--PADDING_SMALL, 20px);
-  margin-inline: var(--PADDING_SMALL, 20px);
+  position: absolute;
+  top: var(--PADDING_SMALL, 20px);
+  left: var(--PADDING_SMALL, 20px);
+  width: calc(100% - var(--PADDING_SMALL, 20px) * 2);
 `;
 
 export const ToolsHeader = styled.div`

--- a/packages/epo-widget-lib/src/widgets/ColorTool/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/styles.ts
@@ -1,6 +1,4 @@
-import styled, { css } from "styled-components";
-import Button from "@rubin-epo/epo-react-lib/Button";
-import HorizontalSlider from "@rubin-epo/epo-react-lib/HorizontalSlider";
+import styled from "styled-components";
 import { token } from "@rubin-epo/epo-react-lib/styles";
 
 export const WidgetContainer = styled.section`
@@ -8,18 +6,17 @@ export const WidgetContainer = styled.section`
   container: colorTool / inline-size;
 `;
 
-const breakSize = token("BREAK_DESKTOP_SMALL");
+const breakSize = token("BREAK_LARGE_TABLET_MIN");
 
 export const WidgetLayout = styled.div`
   --widget-areas: "image" "controls" "actions" "title";
-  --controls-row: "controls image";
   display: grid;
-  gap: var(--PADDING_SMALL, 20px);
+  gap: var(--color-tool-padding, var(--PADDING_SMALL, 20px));
   grid-template-areas: var(--widget-areas);
   grid-template-columns: 1fr;
 
   @container colorTool (min-width: ${breakSize}) {
-    --widget-areas: var(--controls-row) "actions actions" "title title";
+    --widget-areas: "controls image" "actions actions" "title title";
     grid-template-columns: 1fr var(--image-width, 1fr);
   }
 `;
@@ -60,11 +57,6 @@ export const ControlsContainer = styled.div`
   align-items: center;
 `;
 
-export const Slider = styled(HorizontalSlider)`
-  padding: 0;
-  width: 100%;
-`;
-
 export const Image = styled.canvas`
   user-select: none;
   position: absolute;
@@ -81,41 +73,11 @@ export const Image = styled.canvas`
 
 export const SelectionContainer = styled.div`
   position: absolute;
-  top: var(--PADDING_SMALL, 20px);
-  left: var(--PADDING_SMALL, 20px);
-  width: calc(100% - var(--PADDING_SMALL, 20px) * 2);
+  top: var(--color-tool-padding, var(--PADDING_SMALL, 20px));
+  left: var(--color-tool-padding, var(--PADDING_SMALL, 20px));
+  width: calc(100% - var(--color-tool-padding, var(--PADDING_SMALL, 20px)) * 2);
 `;
 
 export const ToolsHeader = styled.div`
   font-weight: var(--FONT_WEIGHT_BOLD, 600);
-`;
-
-export const FilterToggleButton = styled(Button)<{ $active: boolean }>`
-  border-radius: 50%;
-  font-weight: var(--FONT_WEIGHT_MEDIUM, 500);
-  font-size: 22px;
-  text-transform: lowercase;
-  display: flex;
-  width: 38px;
-  height: 38px;
-  padding: 0;
-
-  ${({ $active }) =>
-    $active
-      ? css`
-          background-color: var(--turquoise85, #12726c);
-          &:not(:disabled):not([aria-disabled="true"]):hover {
-            outline: 1px solid var(--white, #fff);
-            outline-offset: -3px;
-          }
-        `
-      : css`
-          background-color: #f7f7f7;
-          border-color: #6c6e6e;
-          color: #6c6e6e !important;
-          &:not(:disabled):not([aria-disabled="true"]):hover {
-            outline: 2px solid #6c6e6e;
-            outline-offset: -2px;
-          }
-        `}
 `;

--- a/packages/epo-widget-lib/src/widgets/ColorTool/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/styles.ts
@@ -1,15 +1,14 @@
 import styled from "styled-components";
-import { token } from "@rubin-epo/epo-react-lib/styles";
 
 export const WidgetContainer = styled.section`
   color: var(--neutral80, #404040);
   container: colorTool / inline-size;
 `;
 
-const breakSize = token("BREAK_LARGE_TABLET_MIN");
+const breakSize = "900px";
 
 export const WidgetLayout = styled.div`
-  --widget-areas: "image" "controls" "actions" "title";
+  --widget-areas: "image" "title" "controls" "actions";
   display: grid;
   gap: var(--color-tool-padding, var(--PADDING_SMALL, 20px));
   grid-template-areas: var(--widget-areas);

--- a/packages/epo-widget-lib/src/widgets/ColorTool/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/styles.ts
@@ -4,6 +4,7 @@ import HorizontalSlider from "@rubin-epo/epo-react-lib/HorizontalSlider";
 import { token } from "@rubin-epo/epo-react-lib/styles";
 
 export const WidgetContainer = styled.section`
+  color: var(--neutral80, #404040);
   container: colorTool / inline-size;
 `;
 

--- a/packages/epo-widget-lib/src/widgets/ColorTool/utilities.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/utilities.ts
@@ -3,6 +3,7 @@ import find from "lodash/find";
 import isEmpty from "lodash/isEmpty";
 import { AstroCategory, AstroObject, ImageFilter } from "./ColorTool";
 
+/** calculates a value that can be used in the CSS {@link https://developer.mozilla.org/en-US/docs/Web/CSS/filter-function/brightness brightness filter } */
 export const getBrightnessValue = (min: number, max: number, value: number) => {
   const s = max - min;
   return s * (value / 100) + min;
@@ -10,12 +11,6 @@ export const getBrightnessValue = (min: number, max: number, value: number) => {
 
 export const isFilterActive = (filters: ImageFilter[]) =>
   filters.some((f) => f.active);
-
-export const isResetButtonActive = (data: AstroObject) => {
-  if (isEmpty(data)) return false;
-
-  return isFilterActive(data.filters);
-};
 
 export const updateFilters = (datum: AstroObject) =>
   datum.filters.map((f) => {
@@ -61,16 +56,8 @@ export const getCategoryName = (data: AstroCategory[], objectName: string) => {
   return type;
 };
 
-export const resetFilters = (filters: ImageFilter[]): ImageFilter[] =>
-  filters.map((filter) => {
-    const { defaultValue, min, max } = filter;
-    const value = defaultValue || 1;
+export const areActionsActive = (data: AstroObject) => {
+  if (isEmpty(data)) return false;
 
-    return {
-      ...filter,
-      active: false,
-      color: "",
-      brightness: getBrightnessValue(value, min, max),
-      value,
-    };
-  });
+  return isFilterActive(data.filters);
+};

--- a/packages/epo-widget-lib/src/widgets/ColorTool/utilities.ts
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/utilities.ts
@@ -61,3 +61,40 @@ export const areActionsActive = (data: AstroObject) => {
 
   return isFilterActive(data.filters);
 };
+
+export function isStyleSupported(prop: string, value: string): boolean {
+  // If no value is supplied, use "inherit"
+  value = arguments.length === 2 ? value : "inherit";
+  // Try the native standard method first
+  if (typeof window !== "undefined") {
+    if ("CSS" in window && "supports" in window.CSS) {
+      return window.CSS.supports(prop, value);
+    }
+    // Check Opera's native method
+    if ("supportsCSS" in window) {
+      return (
+        window.supportsCSS as (property: string, value: string) => boolean
+      )(prop, value);
+    }
+  }
+
+  // node, no way around this
+  if (typeof document === "undefined") {
+    return true;
+  }
+
+  // Convert to camel-case for DOM interactions
+  const camel = prop.replace(/-([a-z]|[0-9])/gi, function (all, letter) {
+    return (letter + "").toUpperCase();
+  });
+  // Create test element
+  const el = document.createElement("div");
+  // Check if the property is supported
+  const support = camel in el.style;
+  // Assign the property and value to invoke
+  // the CSS interpreter
+  el.style.cssText = prop + ":" + value;
+  // Ensure both the property and value are
+  // supported and return
+  return support && el.style[camel as any] !== "";
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9237,6 +9237,11 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+use-image@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/use-image/-/use-image-1.1.1.tgz#bdd3f2e1718393ffc0e56136f993467103d9d2df"
+  integrity sha512-n4YO2k8AJG/BcDtxmBx8Aa+47kxY5m335dJiCQA5tTeVU4XdhrhqR6wT0WISRXwdMEOv5CSjqekDZkEMiiWaYQ==
+
 use-resize-observer@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/use-resize-observer/-/use-resize-observer-9.1.0.tgz#14735235cf3268569c1ea468f8a90c5789fc5c6c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9237,11 +9237,6 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-use-image@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/use-image/-/use-image-1.1.1.tgz#bdd3f2e1718393ffc0e56136f993467103d9d2df"
-  integrity sha512-n4YO2k8AJG/BcDtxmBx8Aa+47kxY5m335dJiCQA5tTeVU4XdhrhqR6wT0WISRXwdMEOv5CSjqekDZkEMiiWaYQ==
-
 use-resize-observer@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/use-resize-observer/-/use-resize-observer-9.1.0.tgz#14735235cf3268569c1ea468f8a90c5789fc5c6c"


### PR DESCRIPTION
Major re-write of the Color Filter Tool, addressing some deep underlying tech debt and expanding the capabilities of the tool.

Includes:

- All filtering (brightness, color, contrast) is done in HTML canvas
- Images loaded via hooks to avoid reloads when props change
- Can export images
- Filter controls correctly use a checkbox instead of button to toggle filters
- Reset works correctly
- Minor design changes
- Clean up read-only mode