### PR TITLE
[C] add Slideout and examples

### DIFF
--- a/packages/epo-react-lib/package.json
+++ b/packages/epo-react-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rubin-epo/epo-react-lib",
   "description": "Rubin Observatory Education & Public Outreach team React UI library.",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "author": "Rubin EPO",
   "license": "MIT",
   "homepage": "https://lsst-epo.github.io/epo-react-lib",

--- a/packages/epo-react-lib/src/atomic/Slideout/Slideout.stories.tsx
+++ b/packages/epo-react-lib/src/atomic/Slideout/Slideout.stories.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { Meta, StoryFn, StoryObj } from "@storybook/react";
+import styled from "styled-components";
+import Button from "../Button";
+
+import Slideout from ".";
+
+const meta: Meta<typeof Slideout> = {
+  component: Slideout,
+  argTypes: {
+    isOpen: {
+      control: "boolean",
+      description: "State that controls if the slideout is opened or not.",
+      type: "boolean",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+        defaultValue: { summary: false },
+      },
+    },
+    onCloseCallback: {
+      action: "Slideout closed",
+      description: "Callback after the slideout has closed",
+      table: {
+        type: {
+          summary: "() => void",
+        },
+      },
+    },
+    onOpenCallback: {
+      action: "Slideout opened",
+      description: "Callback after the slideout has opened",
+      table: {
+        type: {
+          summary: "() => void",
+        },
+      },
+    },
+    slideFrom: {
+      control: "select",
+      options: ["top", "bottom", "left", "right"],
+      description:
+        "Side of the window that the slideout will enter from and be pinned to",
+      table: {
+        type: {
+          summary: "top|bottom|left|right",
+        },
+        defaultValue: { summary: true },
+      },
+    },
+    showBackground: {
+      control: "boolean",
+      description: "Shows a semi-transparent background",
+      type: "boolean",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+        defaultValue: { summary: true },
+      },
+    },
+  },
+};
+export default meta;
+
+const Panel = styled.div`
+  background-color: var(--neutral10);
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  padding: 1em;
+
+  & > * + * {
+    margin-block-start: 1em;
+  }
+`;
+
+const Template: StoryFn<typeof Slideout> = (args) => {
+  const [isOpen, setIsOpen] = useState(args.isOpen || false);
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)} isBlock>
+        Open
+      </Button>
+      <Slideout
+        {...args}
+        isOpen={isOpen}
+        onCloseCallback={() => setIsOpen(false)}
+      >
+        <Panel
+          style={{
+            [args.slideFrom === "top" || args.slideFrom === "bottom"
+              ? "height"
+              : "width"]: "30ch",
+            [args.slideFrom === "top" || args.slideFrom === "bottom"
+              ? "width"
+              : "height"]: "100%",
+          }}
+        >
+          Cosmic ipsum helium perturbation Hubble's law gravity visual magnitude
+          limb equinox Bailey's beads escape velocity eccentricity meteoroid
+          superior planets black hole revolve Oort cloud Sputnik singularity
+          planetoid translunar ice giant Lagrange points twinkling ecliptic
+          apastron circumpolar planet perihelion nebula gibbous moon local arm
+          event horizon space station penumbra orbital eccentricity zodiac
+          eclipse Kepler's laws north star sun wormhole minor planet spectrum
+          deep space dark matter celestial coordinates cosmology asterism moon
+          <Button onClick={() => setIsOpen(false)} isBlock>
+            Close
+          </Button>
+        </Panel>
+      </Slideout>
+    </>
+  );
+};
+
+export const Primary: StoryObj<typeof Slideout> = Template.bind({});

--- a/packages/epo-react-lib/src/atomic/Slideout/Slideout.test.tsx
+++ b/packages/epo-react-lib/src/atomic/Slideout/Slideout.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import Slideout from ".";
+import userEvent from "@testing-library/user-event";
+
+const slideFrom = "bottom";
+const onCloseCallback = jest.fn();
+
+describe("Slideout", () => {
+  it("is visible when opened", () => {
+    render(<Slideout isOpen={true} />);
+
+    const slideout = screen.getByTestId("slideout");
+
+    expect(slideout).toBeVisible();
+  });
+  it("enters from the side selected", () => {
+    render(<Slideout isOpen={true} slideFrom={slideFrom} />);
+
+    const slideout = screen.getByTestId("slideoutContainer");
+
+    expect(slideout).toHaveStyle({ [slideFrom]: "0" });
+  });
+  it("closes when Escape is pressed", () => {
+    render(<Slideout isOpen={true} onCloseCallback={onCloseCallback} />);
+
+    userEvent.keyboard("{Esc}");
+
+    waitFor(() => {
+      expect(onCloseCallback).toBeCalled();
+    });
+  });
+  it("closes when clicked outside of content", () => {
+    render(<Slideout isOpen={true} onCloseCallback={onCloseCallback} />);
+
+    const overlay = screen.getByRole("none");
+    userEvent.click(overlay);
+
+    waitFor(() => {
+      expect(onCloseCallback).toBeCalled();
+    });
+  });
+});

--- a/packages/epo-react-lib/src/atomic/Slideout/index.tsx
+++ b/packages/epo-react-lib/src/atomic/Slideout/index.tsx
@@ -1,0 +1,113 @@
+import { FunctionComponent, PropsWithChildren, useRef } from "react";
+import { Transition } from "@headlessui/react";
+import { useOnClickOutside, useKeyDownEvent } from "@/hooks/listeners";
+import * as Styled from "./styles";
+
+type SlideFrom = "top" | "right" | "bottom" | "left";
+
+export interface SlideoutProps {
+  isOpen?: boolean;
+  onCloseCallback?: () => void;
+  onOpenCallback?: () => void;
+  slideFrom?: SlideFrom;
+  showBackground?: boolean;
+}
+
+const getX = (slideFrom: SlideFrom) => {
+  switch (slideFrom) {
+    case "left":
+      return "-100%";
+    case "right":
+      return "100%";
+    default:
+      return "0";
+  }
+};
+
+const getY = (slideFrom: SlideFrom) => {
+  switch (slideFrom) {
+    case "top":
+      return "-100%";
+    case "bottom":
+      return "100%";
+    default:
+      return "0";
+  }
+};
+
+const Slideout: FunctionComponent<PropsWithChildren<SlideoutProps>> = ({
+  isOpen = false,
+  onOpenCallback,
+  onCloseCallback,
+  slideFrom = "left",
+  showBackground = true,
+  children,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const translation = `translate(${getX(slideFrom)}, ${getY(slideFrom)})`;
+  const styles = {
+    [slideFrom]: 0,
+    [slideFrom === "bottom" || slideFrom === "top" ? "width" : "height"]:
+      "100%",
+  };
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (isOpen) {
+      const { key } = event;
+
+      const keyMap: { [key: string]: () => void } = {
+        Escape: () => onCloseCallback && onCloseCallback(),
+      };
+
+      const action = keyMap[key];
+      if (action) {
+        event.preventDefault();
+        action();
+      }
+    }
+  }
+
+  useOnClickOutside(containerRef, () => onCloseCallback && onCloseCallback());
+  useKeyDownEvent(handleKeyDown);
+
+  return (
+    <Transition
+      as={Styled.Transition}
+      show={isOpen}
+      afterEnter={() => onOpenCallback && onOpenCallback()}
+      afterLeave={() => onCloseCallback && onCloseCallback()}
+      data-testid="slideout"
+    >
+      {showBackground && (
+        <Transition.Child
+          as={Styled.Overlay}
+          role="none"
+          enterFrom="closed"
+          enter="opening"
+          enterTo="open"
+          leaveFrom="open"
+          leave="closing"
+          leaveTo="closed"
+        />
+      )}
+      <Transition.Child
+        ref={containerRef}
+        as={Styled.SlideoutContainer}
+        style={{ "--transform": translation, ...styles }}
+        enterFrom="closed"
+        enter="opening"
+        enterTo="open"
+        leaveFrom="open"
+        leave="closing"
+        leaveTo="closed"
+        data-testid="slideoutContainer"
+      >
+        {children}
+      </Transition.Child>
+    </Transition>
+  );
+};
+
+Slideout.displayName = "Atomic.Slideout";
+
+export default Slideout;

--- a/packages/epo-react-lib/src/atomic/Slideout/styles.ts
+++ b/packages/epo-react-lib/src/atomic/Slideout/styles.ts
@@ -2,9 +2,12 @@ import { zStack } from "@/styles/abstracts";
 import styled from "styled-components";
 
 export const Transition = styled.div`
-  --slide-time: 400ms;
-  --slide-delay: 200ms;
-  --transition-time: calc(var(--slide-time) + var(--slide-delay));
+  --transition-time: calc(var(--slide-time, 0) + var(--slide-delay, 0));
+
+  @media (prefers-reduced-motion: no-preference) {
+    --slide-time: 400ms;
+    --slide-delay: 200ms;
+  }
 
   position: fixed;
   top: 0;
@@ -19,20 +22,24 @@ export const Overlay = styled.div`
   width: 100%;
   height: 100%;
   position: absolute;
-  transition: background-color var(--slide-time);
-  transition-delay: var(--slide-delay);
+  transition: background-color var(--slide-time, 0);
+  transition-delay: var(--slide-delay, 0);
 
   &.closed {
     --background-color: transparent;
   }
 
   &.open {
-    --background-color: rgba(0, 0, 0, 0.7);
+    --background-color: rgba(0, 0, 0, var(--overlay-opacity, 0.9));
+
+    @media (prefers-reduced-transparency: no-preference) {
+      --overlay-opacity: 0.7;
+    }
   }
 `;
 export const SlideoutContainer = styled.div`
   position: absolute;
-  transition: transform var(--slide-time);
+  transition: transform var(--slide-time, 0);
   &.closed {
     transform: var(--transform);
   }

--- a/packages/epo-react-lib/src/atomic/Slideout/styles.ts
+++ b/packages/epo-react-lib/src/atomic/Slideout/styles.ts
@@ -1,0 +1,42 @@
+import { zStack } from "@/styles/abstracts";
+import styled from "styled-components";
+
+export const Transition = styled.div`
+  --slide-time: 400ms;
+  --slide-delay: 200ms;
+  --transition-time: calc(var(--slide-time) + var(--slide-delay));
+
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: ${zStack.dialog};
+`;
+
+export const Overlay = styled.div`
+  background-color: var(--background-color, transparent);
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  transition: background-color var(--slide-time);
+  transition-delay: var(--slide-delay);
+
+  &.closed {
+    --background-color: transparent;
+  }
+
+  &.open {
+    --background-color: rgba(0, 0, 0, 0.7);
+  }
+`;
+export const SlideoutContainer = styled.div`
+  position: absolute;
+  transition: transform var(--slide-time);
+  &.closed {
+    transform: var(--transform);
+  }
+  &.open {
+    transform: translate(0, 0);
+  }
+`;

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.test.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.test.tsx
@@ -54,15 +54,4 @@ describe("Slideout menu", () => {
       expect(document.activeElement?.id).toBe(menuItems[1].id);
     });
   });
-  it("closes the menu when Escape is pressed", () => {
-    render(<SlideoutMenu {...props} />);
-
-    const menu = screen.getByRole("menu");
-
-    userEvent.keyboard("{Esc}");
-
-    waitFor(() => {
-      expect(menu).not.toBeVisible();
-    });
-  });
 });

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.tsx
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/SlideoutMenu.tsx
@@ -6,10 +6,10 @@ import {
   useRef,
   useState,
 } from "react";
-import { useOnClickOutside, useKeyDownEvent } from "@/hooks/listeners";
+import Slideout from "@/atomic/Slideout";
+import { useKeyDownEvent } from "@/hooks/listeners";
 import MenuContext from "@/contexts/Menu";
 import * as Styled from "./styles";
-import { MENU_TRANSITION_TIME } from "./constants";
 import IconComposer from "@/svg/IconComposer/IconComposer";
 
 interface SlideoutMenuProps {
@@ -37,7 +37,6 @@ const SlideoutMenu: FunctionComponent<PropsWithChildren<SlideoutMenuProps>> = ({
   const menuItems = useRef<Set<HTMLButtonElement>>(new Set()).current;
 
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [isHidden, setIsHidden] = useState(!isOpen);
 
   const isActive = isOpen && !isSubMenuOpen;
 
@@ -45,18 +44,6 @@ const SlideoutMenu: FunctionComponent<PropsWithChildren<SlideoutMenuProps>> = ({
     () => ({ menuItems, currentIndex }),
     [menuItems, currentIndex]
   );
-
-  useEffect(() => {
-    if (isOpen) {
-      setTimeout(firstItem);
-      setIsHidden(false);
-      onOpenCallback && onOpenCallback();
-    } else {
-      setTimeout(() => {
-        setIsHidden(true);
-      }, MENU_TRANSITION_TIME);
-    }
-  }, [isOpen]);
 
   useEffect(() => {
     if (isActive) {
@@ -106,7 +93,6 @@ const SlideoutMenu: FunctionComponent<PropsWithChildren<SlideoutMenuProps>> = ({
         ArrowUp: prevItem,
         Home: firstItem,
         End: lastItem,
-        Escape: handleClose,
       };
 
       const action = keyMap[key];
@@ -121,14 +107,9 @@ const SlideoutMenu: FunctionComponent<PropsWithChildren<SlideoutMenuProps>> = ({
   const menuTitleId = `slideOutMenuTitle-${id}`;
 
   useKeyDownEvent(handleKeyDown);
-  useOnClickOutside(menuRef, handleClose);
 
   return (
-    <Styled.Overlay
-      role="none"
-      aria-hidden={!isOpen}
-      style={{ "--visibility": !isHidden && "visible" }}
-    >
+    <Slideout onCloseCallback={handleClose} {...{ isOpen, onOpenCallback }}>
       <Styled.MenuContainer
         ref={menuRef}
         role="menu"
@@ -154,7 +135,7 @@ const SlideoutMenu: FunctionComponent<PropsWithChildren<SlideoutMenuProps>> = ({
         </Styled.MenuHeader>
         <MenuContext.Provider value={value}>{children}</MenuContext.Provider>
       </Styled.MenuContainer>
-    </Styled.Overlay>
+    </Slideout>
   );
 };
 

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/constants.ts
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/constants.ts
@@ -1,3 +1,0 @@
-export const MENU_SLIDE_TIME: number = 400;
-export const MENU_SLIDE_DELAY: number = 200;
-export const MENU_TRANSITION_TIME: number = MENU_SLIDE_TIME + MENU_SLIDE_DELAY;

--- a/packages/epo-react-lib/src/layout/SlideoutMenu/styles.ts
+++ b/packages/epo-react-lib/src/layout/SlideoutMenu/styles.ts
@@ -1,39 +1,6 @@
 import styled from "styled-components";
-import { zStack, BREAK_TABLET_MIN } from "@/styles/abstracts";
+import { BREAK_TABLET_MIN } from "@/styles/abstracts";
 import { protoButton } from "@/styles/mixins/appearance";
-import {
-  MENU_TRANSITION_TIME,
-  MENU_SLIDE_TIME,
-  MENU_SLIDE_DELAY,
-} from "./constants";
-
-export const Overlay = styled.div`
-  --menu-transition-time: ${MENU_TRANSITION_TIME}ms;
-  --menu-slide-time: ${MENU_SLIDE_TIME}ms;
-  --menu-slide-delay: ${MENU_SLIDE_DELAY}ms;
-
-  --background-color: transparent;
-  --pointer-events: none;
-  --transform: translateX(-100%);
-
-  background-color: var(--background-color, transparent);
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: ${zStack.dialog};
-  transition: background-color var(--menu-slide-time);
-  transition-delay: var(--menu-slide-delay);
-  pointer-events: var(--pointer-events);
-  visibility: var(--visibility, hidden);
-
-  &:not([aria-hidden="true"]) {
-    --background-color: rgba(0, 0, 0, 0.7);
-    --pointer-events: auto;
-    --transform: translateX(0);
-  }
-`;
 
 export const MenuContainer = styled.div`
   --menu-padding: var(--PADDING_SMALL, 20px);
@@ -45,12 +12,6 @@ export const MenuContainer = styled.div`
   height: 100%;
   width: 20rem;
   max-width: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  transition: transform var(--menu-slide-time) ease-in;
-  transition-delay: var(--menu-slide-delay);
-  transform: var(--transform);
   overflow-y: auto;
 
   & > * + * {

--- a/packages/epo-react-lib/src/svg/icons/DocArrowRight.tsx
+++ b/packages/epo-react-lib/src/svg/icons/DocArrowRight.tsx
@@ -1,0 +1,28 @@
+import { FunctionComponent } from "react";
+import { SVGProps } from "@/types/svg";
+import defaultProps from "./defaultProps";
+
+const DocArrowRight: FunctionComponent<SVGProps> = ({
+  className,
+  size = 24,
+  fill = "currentColor",
+}) => {
+  const uniqueProps = {
+    viewBox: "0 0 18.124 15",
+    width: size,
+    height: size,
+    fill,
+    className,
+  };
+
+  const mergedSvgProps = Object.assign(defaultProps, uniqueProps);
+  return (
+    <svg {...mergedSvgProps}>
+      <path d="M12.084,3.571a.677.677,0,0,0-.22-.5L8.783.205A.784.784,0,0,0,8.248,0H8.056V3.75h4.028Zm5.885,5.452L14.957,6.2a.51.51,0,0,0-.862.331V8.438H12.081v1.875h2.014v1.91a.51.51,0,0,0,.862.331l3.012-2.827A.475.475,0,0,0,17.968,9.023Zm-11.926.82V8.906a.488.488,0,0,1,.5-.469h5.538V4.688H7.8a.733.733,0,0,1-.755-.7V0H.755A.729.729,0,0,0,0,.7V14.3a.729.729,0,0,0,.755.7H11.329a.729.729,0,0,0,.755-.7V10.313H6.545A.488.488,0,0,1,6.042,9.844Z" />
+    </svg>
+  );
+};
+
+DocArrowRight.displayName = "SVG.DocArrowRight";
+
+export default DocArrowRight;

--- a/packages/epo-react-lib/src/svg/icons/DocInverted.tsx
+++ b/packages/epo-react-lib/src/svg/icons/DocInverted.tsx
@@ -1,0 +1,31 @@
+import { FunctionComponent } from "react";
+import { SVGProps } from "@/types/svg";
+import defaultProps from "./defaultProps";
+
+const DocInverted: FunctionComponent<SVGProps> = ({
+  className,
+  size = 24,
+  fill = "currentColor",
+}) => {
+  const uniqueProps = {
+    viewBox: "0 0 14.297 18.117",
+    width: size,
+    height: size,
+    fill,
+    className,
+  };
+
+  const mergedSvgProps = Object.assign(defaultProps, uniqueProps);
+  return (
+    <svg {...mergedSvgProps}>
+      <path
+        d="M14.936,3H7.787A1.8,1.8,0,0,0,6.009,4.812L6,19.305a1.8,1.8,0,0,0,1.778,1.812H18.51A1.8,1.8,0,0,0,20.3,19.305V8.435Z"
+        transform="translate(-6 -3)"
+      />
+    </svg>
+  );
+};
+
+DocInverted.displayName = "SVG.DocInverted";
+
+export default DocInverted;

--- a/packages/epo-react-lib/src/svg/icons/index.ts
+++ b/packages/epo-react-lib/src/svg/icons/index.ts
@@ -17,6 +17,8 @@ import Close from "./Close";
 import CloseCircle from "./CloseCircle";
 import Cloud from "./Cloud";
 import Doc from "./Doc";
+import DocInverted from "./DocInverted";
+import DocArrowRight from "./DocArrowRight";
 import Email from "./Email";
 import Expand from "./Expand";
 import Eye from "./Eye";
@@ -85,6 +87,8 @@ const Icons = {
   CloseCircle,
   Cloud,
   Doc,
+  DocArrowRight,
+  DocInverted,
   Email,
   Expand,
   Eye,

--- a/packages/epo-react-lib/vite.config.ts
+++ b/packages/epo-react-lib/vite.config.ts
@@ -107,6 +107,7 @@ export default defineConfig({
           "src/svg/IconComposer/IconComposer.tsx"
         ),
         icons: resolve(__dirname, "src/svg/icons"),
+        Slideout: resolve(__dirname, "src/atomic/Slideout/index.tsx"),
       },
       formats: [defaultFormat, "cjs"],
       fileName: (format, name) =>


### PR DESCRIPTION
JIRA: https://jira.lsstcorp.org/browse/EPO-8858

## What this change does

Refactor out the sliding component from the Slideout menu into it's own atomic component

## Notes for reviewers

Check out the new "Slideout" example in Storybook and with the corresponding branch for Investigations. `yarn publish:local` in the libraries and then `yarn add file:[path to @rubin-epo/epo-react-lib/packages/epo-react-lib/tempPublish]`

- 3

## Testing

New tests in PR

## Screenshots (optional)

### Before:

### After:
