### PR TITLE
[B] fix crossorigin error

### DIFF
--- a/packages/epo-widget-lib/CHANGELOG.md
+++ b/packages/epo-widget-lib/CHANGELOG.md
@@ -28,3 +28,7 @@
 - add `useAxis` hook
 - add `LightCurvePlot`
 - refactor `ColorTool` to perform callbacks correctly when images load from cache
+
+## 0.9.2
+
+- add `crossOrigin = "anonymous"` to `useFilteredImages`

--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubin-epo/epo-widget-lib",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Rubin Observatory Education & Public Outreach team React scientific and educational widgets.",
   "author": "Rubin EPO",
   "license": "MIT",

--- a/packages/epo-widget-lib/src/widgets/ColorTool/hooks/useFilteredImages.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/hooks/useFilteredImages.tsx
@@ -28,6 +28,7 @@ const useFilteredImages = ({
       setImages(
         images.map(({ url, width, height }) => {
           const img = new Image(width, height);
+          img.crossOrigin = "anonymous";
           img.onload = () => {
             setImagesLoaded((value) => value + 1);
           };


### PR DESCRIPTION
Add `crossOrigin = "anonymous"` to the `useFilteredImages` hook to prevent security error in Safari