### PR TITLE
[C] Firefox + Safari compatibility fixes

### DIFF
--- a/packages/epo-widget-lib/CHANGELOG.md
+++ b/packages/epo-widget-lib/CHANGELOG.md
@@ -32,3 +32,7 @@
 ## 0.9.2
 
 - add `crossOrigin = "anonymous"` to `useFilteredImages`
+
+## 0.9.3
+
+- Firefox and Safari compatibility fixes for `LightCurvePlot`

--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubin-epo/epo-widget-lib",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Rubin Observatory Education & Public Outreach team React scientific and educational widgets.",
   "author": "Rubin EPO",
   "license": "MIT",

--- a/packages/epo-widget-lib/src/charts/Base/index.tsx
+++ b/packages/epo-widget-lib/src/charts/Base/index.tsx
@@ -41,12 +41,12 @@ const BaseChart: FunctionComponent<PropsWithChildren<BaseChartProps>> = ({
         className={className}
         style={{
           "--aspect-ratio": `${width} / ${height}`,
-          "--min-width": `${width}px`,
         }}
         role="group"
       >
         {children}
       </Styled.SVG>
+
       {horizontalLabel && (
         <Styled.HorizontalLabel
           id={horizontalLabelId}

--- a/packages/epo-widget-lib/src/charts/Base/styles.ts
+++ b/packages/epo-widget-lib/src/charts/Base/styles.ts
@@ -1,16 +1,17 @@
 import styled from "styled-components";
 
 export const ChartContainer = styled.div`
-  --label-gutter: 2em;
+  --label-height: 3em;
+  --label-gutter: calc(var(--label-height) / 2);
 
   display: grid;
-  grid-template-columns: var(--label-gutter) 1fr;
-  grid-template-rows: auto 1fr var(--label-gutter);
+  grid-template-columns: var(--label-height) 1fr var(--label-height);
+  grid-template-rows: var(--label-height) 1fr var(--label-height);
   grid-template-areas:
-    "title title"
-    "vertical-label chart"
-    ". horizontal-label";
-  padding-inline-end: calc(var(--label-gutter) / 2);
+    "title title ."
+    "vertical-label chart ."
+    ". horizontal-label .";
+  width: 100%;
 `;
 
 export const HorizontalLabel = styled.span`
@@ -30,7 +31,6 @@ export const VerticalLabel = styled.span`
 
 export const SVG = styled.svg`
   grid-area: chart;
-  height: 100%;
   max-width: 100%;
   aspect-ratio: var(--aspect-ratio);
 `;
@@ -39,7 +39,6 @@ export const Title = styled.h3`
   display: flex;
   align-items: center;
   grid-area: title;
-  height: var(--label-gutter);
-  padding-inline: calc(var(--label-gutter) / 2);
+  padding-inline: var(--label-gutter);
   margin: 0;
 `;

--- a/packages/epo-widget-lib/src/charts/ForeignObject/index.tsx
+++ b/packages/epo-widget-lib/src/charts/ForeignObject/index.tsx
@@ -1,16 +1,18 @@
 import { FunctionComponent, PropsWithChildren } from "react";
 
 const ForeignObject: FunctionComponent<
-  PropsWithChildren<{ className?: string }>
-> = ({ children, className }) => {
+  PropsWithChildren<{
+    className?: string;
+    width?: number | string;
+    height?: number | string;
+  }>
+> = ({ children, className, width = "100%", height = "100%" }) => {
   return (
     <foreignObject
-      className={className}
       x={0}
       y={0}
-      width="100%"
-      height="100%"
       pointerEvents="none"
+      {...{ className, width, height }}
     >
       {children}
     </foreignObject>

--- a/packages/epo-widget-lib/src/charts/Tooltip/index.tsx
+++ b/packages/epo-widget-lib/src/charts/Tooltip/index.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent, PropsWithChildren } from "react";
 import * as Styled from "./styles";
+import { isSafari } from "@/lib/utils";
 
 export interface TooltipProps {
   x?: number;
@@ -94,9 +95,17 @@ const Tooltip: FunctionComponent<PropsWithChildren<TooltipProps>> = ({
       {typeof x === "number" && typeof y === "number" && (
         <Styled.Tooltip
           className={className}
-          style={{
-            transform: `translate(calc(${xOffset} + ${x}px), calc(${yOffset} + ${y}px))`,
-          }}
+          style={
+            isSafari()
+              ? {
+                  left: `${x}px`,
+                  top: `${y}px`,
+                  transform: `translate(${xOffset},${yOffset})`,
+                }
+              : {
+                  transform: `translate(calc(${xOffset} + ${x}px), calc(${yOffset} + ${y}px))`,
+                }
+          }
           hidden={!visible}
         >
           {children}

--- a/packages/epo-widget-lib/src/charts/Tooltip/styles.ts
+++ b/packages/epo-widget-lib/src/charts/Tooltip/styles.ts
@@ -12,7 +12,7 @@ export const Tooltip = styled.div`
   line-height: 1;
   padding: 2px 4px;
   text-align: center;
-  position: absolute;
+  position: fixed;
 `;
 
 export const Arrow = styled.div`

--- a/packages/epo-widget-lib/src/lib/utils.ts
+++ b/packages/epo-widget-lib/src/lib/utils.ts
@@ -75,3 +75,9 @@ export const precision = (number: number, precision: number) => {
   const n = precision < 0 ? number : 0.01 / factor + number;
   return Math.round(n * factor) / factor;
 };
+
+export const isSafari = (): boolean => {
+  const chromeInAgent = navigator.userAgent.indexOf("Chrome") > -1;
+  const safariInAgent = navigator.userAgent.indexOf("Safari") > -1;
+  return safariInAgent && !chromeInAgent;
+};

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/DM15Display/index.jsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/DM15Display/index.jsx
@@ -21,26 +21,28 @@ const DM15Display = ({ gaussianWidth, className }) => {
 
   return (
     <ForeignObject>
-      <Styled.DisplayContainer className={className}>
-        <Styled.Line />
-        <math xmlns="http://www.w3.org/1998/Math/MathML">
-          <mn>&Delta;</mn>
-          <msub>
-            <mi>m</mi>
-            <mn>15</mn>
-          </msub>
-          <mo>=</mo>
-          <mn
-            role="status"
-            aria-live="polite"
-            aria-label={t("light_curve.deltaM15.label") || undefined}
-          >
-            {Number(dm15).toLocaleString(language, {
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2,
-            })}
-          </mn>
-        </math>
+      <Styled.DisplayContainer>
+        <Styled.Display className={className}>
+          <Styled.Line />
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <mn>&Delta;</mn>
+            <msub>
+              <mi>m</mi>
+              <mn>15</mn>
+            </msub>
+            <mo>=</mo>
+            <mn
+              role="status"
+              aria-live="polite"
+              aria-label={t("light_curve.deltaM15.label") || undefined}
+            >
+              {Number(dm15).toLocaleString(language, {
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              })}
+            </mn>
+          </math>
+        </Styled.Display>
       </Styled.DisplayContainer>
     </ForeignObject>
   );

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/DM15Display/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/DM15Display/styles.ts
@@ -1,12 +1,15 @@
 import styled from "styled-components";
 
 export const DisplayContainer = styled.div`
-  position: absolute;
-  top: 0;
-  right: 0;
+  display: flex;
+  justify-content: end;
+  align-items: start;
+`;
+export const Display = styled.div`
   display: flex;
   align-items: center;
   gap: 1ch;
+  min-height: 1em;
 `;
 
 export const Line = styled.div`

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/MagnitudeSlider/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/MagnitudeSlider/index.tsx
@@ -10,6 +10,8 @@ interface MagnitudeSliderProps {
   onMagnitudeChangeCallback: (value: number) => void;
   estimatedPeak: number;
   disabled?: boolean;
+  width?: number;
+  height?: number;
 }
 
 const distanceContext = (
@@ -46,6 +48,8 @@ const MagnitudeSlider: FunctionComponent<MagnitudeSliderProps> = ({
   onMagnitudeChangeCallback,
   estimatedPeak,
   disabled,
+  width,
+  height,
 }) => {
   const {
     t,
@@ -53,7 +57,7 @@ const MagnitudeSlider: FunctionComponent<MagnitudeSliderProps> = ({
   } = useTranslation();
 
   return (
-    <ForeignObject>
+    <ForeignObject {...{ width, height }}>
       <Styled.Slider
         ariaLabel={t("light_curve.magnitude_slider.label") || undefined}
         orientation="vertical"
@@ -72,9 +76,13 @@ const MagnitudeSlider: FunctionComponent<MagnitudeSliderProps> = ({
           })
         }
         onChange={onMagnitudeChangeCallback}
-        renderThumb={({ key, ...props }) => {
+        renderThumb={({ key, style, ...props }) => {
           return (
-            <Styled.ThumbContainer key={key} {...props}>
+            <Styled.ThumbContainer
+              key={key}
+              {...props}
+              style={{ ...style, position: "fixed" }}
+            >
               <Styled.ThumbBar />
               <Styled.ThumbHandle />
             </Styled.ThumbContainer>

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/index.tsx
@@ -106,7 +106,7 @@ const PlotWithLightCurve: FunctionComponent<PlotWithLightCurveProps> = ({
                 onUserMagnitudeChangeCallback(v)
               }
               disabled={isDisplayOnly}
-              {...{ yMin, yMax, yScale, estimatedPeak }}
+              {...{ yMin, yMax, yScale, estimatedPeak, width, height }}
             />
             <Styled.DM15Display {...{ gaussianWidth }} />
           </>


### PR DESCRIPTION

## What this change does

Compatibility fixes for Firefox and Safari

## Notes for reviewers

Fixes:
- Plot grid container not spanning parent width (Firefox)
- delta m15 display in wrong location (Safari)
- magnitude slider in wrong location (Safari)
- tooltips in wrong location (Safari)

- 2

## Testing

Validate above in Storybook + no new errors in Chrome

## Screenshots (optional)

### Before:

### After:
