### PR TITLE
[C] light curve tool fixes

### DIFF
--- a/packages/epo-widget-lib/CHANGELOG.md
+++ b/packages/epo-widget-lib/CHANGELOG.md
@@ -49,3 +49,8 @@
 ## 0.9.7
 
 - set `yMin` to always equal bottom of scatterplot, set `yMax` to always equal top.
+
+## 0.9.8
+
+- fix to `LightCurvePlot`
+- change localization text

--- a/packages/epo-widget-lib/public/localeStrings/en/epo-widget-lib.json
+++ b/packages/epo-widget-lib/public/localeStrings/en/epo-widget-lib.json
@@ -107,8 +107,8 @@
     },
     "curve": {
       "controls": {
-        "gaussian_width": "Gaussian Width",
-        "y_offset": "Y Offset"
+        "gaussian_width": "Curve Width",
+        "y_offset": "Vertical (y) Offset"
       },
       "description_above": "Mean distance from observations is {{residual}}, your peak is above the brightest measurement of {{brightest}}",
       "description_below": "Mean distance from observations is {{residual}}, your peak is below the brightest measurement of {{brightest}}"

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/LightCurve/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/LightCurve/index.tsx
@@ -32,7 +32,7 @@ const LightCurve: FunctionComponent<LightCurveProps> = ({
 
   return (
     <path
-      transform={`translate(0,${yScale(yDomain[0] - yOffset)})`}
+      transform={`translate(0,${yScale(yDomain[1] - yOffset)})`}
       d={curve}
       fill="none"
       strokeWidth={2}

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/MagnitudeSlider/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/MagnitudeSlider/index.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent } from "react";
 import { useTranslation } from "react-i18next";
-import { ForeignObject } from "@/charts/index";
 import * as Styled from "./styles";
 
 interface MagnitudeSliderProps {
@@ -48,23 +47,21 @@ const MagnitudeSlider: FunctionComponent<MagnitudeSliderProps> = ({
   onMagnitudeChangeCallback,
   estimatedPeak,
   disabled,
-  width,
-  height,
 }) => {
   const {
     t,
     i18n: { language },
   } = useTranslation();
 
+  const min = yMin > yMax ? yMax : yMin;
+  const max = yMin > yMax ? yMin : yMax;
+
   return (
     <Styled.Slider
       ariaLabel={t("light_curve.magnitude_slider.label") || undefined}
       orientation="vertical"
       value={magnitude}
-      min={yMin}
-      max={yMax}
       step={0.1}
-      disabled={disabled}
       ariaValuetext={() =>
         t("light_curve.magnitude_slider.value", {
           ...distanceContext(estimatedPeak, magnitude, language),
@@ -83,6 +80,7 @@ const MagnitudeSlider: FunctionComponent<MagnitudeSliderProps> = ({
           </Styled.ThumbContainer>
         );
       }}
+      {...{ min, max, disabled }}
     />
   );
 };

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/MagnitudeSlider/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/MagnitudeSlider/index.tsx
@@ -53,8 +53,8 @@ const MagnitudeSlider: FunctionComponent<MagnitudeSliderProps> = ({
     i18n: { language },
   } = useTranslation();
 
-  const min = yMin > yMax ? yMax : yMin;
-  const max = yMin > yMax ? yMin : yMax;
+  const min = Math.min(yMin, yMax);
+  const max = Math.max(yMin, yMax);
 
   return (
     <Styled.Slider

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/index.tsx
@@ -70,7 +70,7 @@ const PlotWithLightCurve: FunctionComponent<PlotWithLightCurveProps> = ({
     min: yMin,
     max: yMax,
     step: defaults.yStep,
-    range: [0, height],
+    range: [height, 0],
   });
 
   const estimatedPeak = estimateMagnitudeWithOffset(0, gaussianWidth, yOffset);

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/ScatterPlot/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/ScatterPlot/index.tsx
@@ -122,7 +122,9 @@ const ScatterPlot: FunctionComponent<PropsWithChildren<ScatterPlotProps>> = ({
             y={yScale(yDomain[1])}
             width={xScale(15) - xScale(0)}
             height={yRoot - yScale(yDomain[1])}
-            fill="#F5F5F5"
+            stroke="var(--neutral60,##6A6E6E)"
+            strokeDasharray={6}
+            fill="var(--neutral20,#DCE0E3)"
           />
           <g
             role="list"
@@ -166,9 +168,9 @@ const ScatterPlot: FunctionComponent<PropsWithChildren<ScatterPlotProps>> = ({
         />
         <Viewport
           x={xRoot}
-          y={yScale(yDomain[0])}
+          y={yScale(yDomain[1])}
           outerWidth={xRange[1] - xRange[0]}
-          outerHeight={yRange[1] - yRange[0]}
+          outerHeight={yRange[0] - yRange[1]}
           innerWidth={width}
           innerHeight={height}
         >


### PR DESCRIPTION
Fixes:

- Localization text
- Set min/max of slider based on the numeric min/max instead of what is defined as min/max
- Invert plot with curve
- Darken and outline 15 day observation box