### PR TITLE
Aspect ratio enforcement + standard widget layout

### DIFF
--- a/packages/epo-widget-lib/.storybook/decorators.tsx
+++ b/packages/epo-widget-lib/.storybook/decorators.tsx
@@ -13,10 +13,24 @@ const withTheme: Decorator = (StoryFn) => {
   );
 };
 
+const Container: Decorator = (StoryFn) => {
+  return (
+    <div
+      style={{
+        "--widget-max-height": "calc(100vh - 2rem)",
+        containerType: "inline-size",
+      }}
+    >
+      {StoryFn()}
+    </div>
+  );
+};
+
 // export all decorators that should be globally applied in an array
 export const globalDecorators = [
   withTheme,
   withTests({
     results,
   }),
+  Container,
 ];

--- a/packages/epo-widget-lib/CHANGELOG.md
+++ b/packages/epo-widget-lib/CHANGELOG.md
@@ -54,3 +54,7 @@
 
 - fix to `LightCurvePlot`
 - change localization text
+
+## 0.9.9
+
+- add `AspectRatio` and `Controls` layouts

--- a/packages/epo-widget-lib/jest.config.ts
+++ b/packages/epo-widget-lib/jest.config.ts
@@ -9,6 +9,7 @@ const config: JestConfigWithTsJest = {
     "^@/assets(.*)$": "<rootDir>/src/assets$1",
     "^@/atomic(.*)$": "<rootDir>/src/atomic$1",
     "^@/hooks(.*)$": "<rootDir>/src/hooks$1",
+    "^@/layout(.*)$": "<rootDir>/src/layout$1",
     "^@/lib(.*)$": "<rootDir>/src/lib$1",
     "^@/storybook(.*)$": "<rootDir>/.storybook$1",
     "^@/styles(.*)$": "<rootDir>/src/styles$1",

--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubin-epo/epo-widget-lib",
-  "version": "0.9.7",
+  "version": "0.9.9-beta.1",
   "description": "Rubin Observatory Education & Public Outreach team React scientific and educational widgets.",
   "author": "Rubin EPO",
   "license": "MIT",

--- a/packages/epo-widget-lib/src/hooks/useWindowSize.ts
+++ b/packages/epo-widget-lib/src/hooks/useWindowSize.ts
@@ -1,0 +1,29 @@
+import { useLayoutEffect, useState } from "react";
+
+export default function useWindowSize() {
+  const [size, setSize] = useState<{
+    width: number | null;
+    height: number | null;
+  }>({
+    width: null,
+    height: null,
+  });
+
+  useLayoutEffect(() => {
+    const handleResize = () => {
+      setSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    handleResize();
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  return size;
+}

--- a/packages/epo-widget-lib/src/layout/AspectRatio/AspectRatio.stories.tsx
+++ b/packages/epo-widget-lib/src/layout/AspectRatio/AspectRatio.stories.tsx
@@ -35,17 +35,11 @@ const Filler = styled.div`
   height: 100%;
 `;
 
-const Container = styled.div`
-  container-type: inline-size;
-`;
-
 const Template: StoryFn<typeof AspectRatio> = (args) => {
   return (
-    <Container>
-      <AspectRatio {...args}>
-        <Filler />
-      </AspectRatio>
-    </Container>
+    <AspectRatio {...args}>
+      <Filler />
+    </AspectRatio>
   );
 };
 

--- a/packages/epo-widget-lib/src/layout/AspectRatio/AspectRatio.stories.tsx
+++ b/packages/epo-widget-lib/src/layout/AspectRatio/AspectRatio.stories.tsx
@@ -1,0 +1,57 @@
+import { Meta, StoryFn, StoryObj } from "@storybook/react";
+import styled from "styled-components";
+import AspectRatio from ".";
+
+const options = {
+  Square: "square",
+  Landscape: "landscape",
+  Portrait: "portrait",
+  None: undefined,
+};
+
+const meta: Meta<typeof AspectRatio> = {
+  argTypes: {
+    ratio: {
+      control: "select",
+      options,
+    },
+    medScreenRatio: {
+      control: "select",
+      options,
+    },
+    smallScreenRatio: {
+      control: "select",
+      options,
+    },
+  },
+  component: AspectRatio,
+};
+export default meta;
+
+const Filler = styled.div`
+  background-color: var(--neutral30);
+  border-radius: 5px;
+  width: 100%;
+  height: 100%;
+`;
+
+const Container = styled.div`
+  container-type: inline-size;
+`;
+
+const Template: StoryFn<typeof AspectRatio> = (args) => {
+  return (
+    <Container>
+      <AspectRatio {...args}>
+        <Filler />
+      </AspectRatio>
+    </Container>
+  );
+};
+
+export const Primary: StoryObj<typeof AspectRatio> = Template.bind({});
+Primary.args = {
+  ratio: "landscape",
+  medScreenRatio: "square",
+  smallScreenRatio: "portrait",
+};

--- a/packages/epo-widget-lib/src/layout/AspectRatio/index.tsx
+++ b/packages/epo-widget-lib/src/layout/AspectRatio/index.tsx
@@ -1,0 +1,78 @@
+import { FunctionComponent, PropsWithChildren } from "react";
+import useWindowSize from "@/hooks/useWindowsize";
+import * as Styled from "./styles";
+
+type AspectRatio = "square" | "portrait" | "landscape";
+interface RangedRatio {
+  narrow: number;
+  wide: number;
+}
+
+export interface AspectRatioProps {
+  ratio: AspectRatio;
+  medScreenRatio?: AspectRatio;
+  smallScreenRatio?: AspectRatio;
+  className?: string;
+}
+
+const getClosestRatio = (screenRatio: number, targetRatio: AspectRatio) => {
+  const ratios: Record<"portrait" | "landscape", RangedRatio> = {
+    portrait: {
+      narrow: parseFloat((9 / 16).toFixed(3)),
+      wide: parseFloat((4 / 5).toFixed(3)),
+    },
+    landscape: {
+      narrow: parseFloat((16 / 9).toFixed(3)),
+      wide: parseFloat((5 / 4).toFixed(3)),
+    },
+  };
+
+  if (targetRatio === "square") {
+    return 1;
+  } else {
+    const {
+      [targetRatio]: { narrow, wide },
+    } = ratios;
+
+    return [narrow, wide].reduce((prev, curr) => {
+      return Math.abs(curr - screenRatio) < Math.abs(prev - screenRatio)
+        ? curr
+        : prev;
+    });
+  }
+};
+
+/**
+ * Wrapper component for widgets that can accept up to 3 target ratios for
+ * wide screens, medium screens, and small screens. Will resize the container
+ * based on it's parent container width and screen height.
+ *
+ * For best results this component should be placed in a container with
+ * `container-type: inline-size` applied.
+ */
+const AspectRatio: FunctionComponent<PropsWithChildren<AspectRatioProps>> = ({
+  ratio,
+  medScreenRatio = ratio,
+  smallScreenRatio = ratio,
+  children,
+  className,
+}) => {
+  const { width, height } = useWindowSize();
+  const screenRatio = width && height ? width / height : 16 / 9;
+
+  const cssVariables = {
+    "--aspect-large-ratio": getClosestRatio(screenRatio, ratio),
+    "--aspect-med-ratio": getClosestRatio(screenRatio, medScreenRatio),
+    "--aspect-small-ratio": getClosestRatio(screenRatio, smallScreenRatio),
+  };
+
+  return (
+    <Styled.AspectRatio style={cssVariables} className={className}>
+      {children}
+    </Styled.AspectRatio>
+  );
+};
+
+AspectRatio.displayName = "Layout.AspectRatio";
+
+export default AspectRatio;

--- a/packages/epo-widget-lib/src/layout/AspectRatio/index.tsx
+++ b/packages/epo-widget-lib/src/layout/AspectRatio/index.tsx
@@ -1,12 +1,7 @@
 import { FunctionComponent, PropsWithChildren } from "react";
-import useWindowSize from "@/hooks/useWindowsize";
 import * as Styled from "./styles";
 
 type AspectRatio = "square" | "portrait" | "landscape";
-interface RangedRatio {
-  narrow: number;
-  wide: number;
-}
 
 export interface AspectRatioProps {
   ratio: AspectRatio;
@@ -15,31 +10,10 @@ export interface AspectRatioProps {
   className?: string;
 }
 
-const getClosestRatio = (screenRatio: number, targetRatio: AspectRatio) => {
-  const ratios: Record<"portrait" | "landscape", RangedRatio> = {
-    portrait: {
-      narrow: parseFloat((9 / 16).toFixed(3)),
-      wide: parseFloat((4 / 5).toFixed(3)),
-    },
-    landscape: {
-      narrow: parseFloat((16 / 9).toFixed(3)),
-      wide: parseFloat((5 / 4).toFixed(3)),
-    },
-  };
-
-  if (targetRatio === "square") {
-    return 1;
-  } else {
-    const {
-      [targetRatio]: { narrow, wide },
-    } = ratios;
-
-    return [narrow, wide].reduce((prev, curr) => {
-      return Math.abs(curr - screenRatio) < Math.abs(prev - screenRatio)
-        ? curr
-        : prev;
-    });
-  }
+const ratios: Record<AspectRatio, number> = {
+  square: 1,
+  portrait: parseFloat((9 / 16).toFixed(3)),
+  landscape: parseFloat((16 / 9).toFixed(3)),
 };
 
 /**
@@ -57,13 +31,10 @@ const AspectRatio: FunctionComponent<PropsWithChildren<AspectRatioProps>> = ({
   children,
   className,
 }) => {
-  const { width, height } = useWindowSize();
-  const screenRatio = width && height ? width / height : 16 / 9;
-
   const cssVariables = {
-    "--aspect-large-ratio": getClosestRatio(screenRatio, ratio),
-    "--aspect-med-ratio": getClosestRatio(screenRatio, medScreenRatio),
-    "--aspect-small-ratio": getClosestRatio(screenRatio, smallScreenRatio),
+    "--aspect-large-ratio": ratios[ratio],
+    "--aspect-med-ratio": ratios[medScreenRatio],
+    "--aspect-small-ratio": ratios[smallScreenRatio],
   };
 
   return (

--- a/packages/epo-widget-lib/src/layout/AspectRatio/styles.ts
+++ b/packages/epo-widget-lib/src/layout/AspectRatio/styles.ts
@@ -1,0 +1,18 @@
+"use client";
+import styled from "styled-components";
+import { token } from "@rubin-epo/epo-react-lib/styles";
+
+export const AspectRatio = styled.div`
+  --widget-max-width: 100vh;
+  --aspect-ratio: var(--aspect-small-ratio, 1);
+
+  aspect-ratio: var(--aspect-ratio);
+  max-width: calc(var(--widget-max-width) * var(--aspect-ratio));
+
+  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
+    --aspect-ratio: var(--aspect-med-ratio, 1);
+  }
+  @container (min-width: ${token("BREAK_DESKTOP_SMALL")}) {
+    --aspect-ratio: var(--aspect-large-ratio, 1);
+  }
+`;

--- a/packages/epo-widget-lib/src/layout/AspectRatio/styles.ts
+++ b/packages/epo-widget-lib/src/layout/AspectRatio/styles.ts
@@ -5,14 +5,12 @@ import { token } from "@rubin-epo/epo-react-lib/styles";
 export const AspectRatio = styled.div`
   --aspect-ratio: var(--aspect-small-ratio, 1);
 
-  height: 100vh;
+  aspect-ratio: var(--aspect-ratio);
   position: relative;
+  max-width: calc(var(--widget-max-height, 100vh) * var(--aspect-ratio));
+  max-height: var(--widget-max-height, 100vh);
+  width: 100%;
 
-  @container (min-width: ${token("BREAK_MOBILE")}) {
-    max-width: calc(var(--widget-max-width, 100vh) * var(--aspect-ratio));
-    height: auto;
-    aspect-ratio: var(--aspect-ratio);
-  }
   @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
     --aspect-ratio: var(--aspect-med-ratio, 1);
   }

--- a/packages/epo-widget-lib/src/layout/AspectRatio/styles.ts
+++ b/packages/epo-widget-lib/src/layout/AspectRatio/styles.ts
@@ -3,12 +3,16 @@ import styled from "styled-components";
 import { token } from "@rubin-epo/epo-react-lib/styles";
 
 export const AspectRatio = styled.div`
-  --widget-max-width: 100vh;
   --aspect-ratio: var(--aspect-small-ratio, 1);
 
-  aspect-ratio: var(--aspect-ratio);
-  max-width: calc(var(--widget-max-width) * var(--aspect-ratio));
+  height: 100vh;
+  position: relative;
 
+  @container (min-width: ${token("BREAK_MOBILE")}) {
+    max-width: calc(var(--widget-max-width, 100vh) * var(--aspect-ratio));
+    height: auto;
+    aspect-ratio: var(--aspect-ratio);
+  }
   @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
     --aspect-ratio: var(--aspect-med-ratio, 1);
   }

--- a/packages/epo-widget-lib/src/layout/Controls/Controls.stories.tsx
+++ b/packages/epo-widget-lib/src/layout/Controls/Controls.stories.tsx
@@ -1,0 +1,51 @@
+import { Meta, StoryFn, StoryObj } from "@storybook/react";
+import styled from "styled-components";
+import Controls from ".";
+import ResetButton from "@/atomic/Button/patterns/Reset";
+
+const meta: Meta<typeof Controls> = {
+  argTypes: {},
+  component: Controls,
+};
+export default meta;
+
+const Widget = styled.div`
+  background-color: var(--neutral30);
+  border-radius: 5px;
+  width: 100%;
+  height: 100%;
+`;
+
+const Control = styled.div`
+  background-color: var(--neutral30);
+  border-radius: 5px;
+  width: 100%;
+  height: 2rem;
+`;
+
+const Container = styled.div`
+  container-type: inline-size;
+`;
+
+const Template: StoryFn<typeof Controls> = (args) => {
+  return (
+    <Container>
+      <Controls
+        {...args}
+        widget={<Widget />}
+        controls={
+          <>
+            <Control />
+            <Control />
+            <Control />
+          </>
+        }
+        caption="Selected Object"
+        actions={<ResetButton onResetCallback={() => undefined} />}
+      />
+    </Container>
+  );
+};
+
+export const Primary: StoryObj<typeof Controls> = Template.bind({});
+Primary.args = {};

--- a/packages/epo-widget-lib/src/layout/Controls/Controls.stories.tsx
+++ b/packages/epo-widget-lib/src/layout/Controls/Controls.stories.tsx
@@ -23,27 +23,21 @@ const Control = styled.div`
   height: 2rem;
 `;
 
-const Container = styled.div`
-  container-type: inline-size;
-`;
-
 const Template: StoryFn<typeof Controls> = (args) => {
   return (
-    <Container>
-      <Controls
-        {...args}
-        widget={<Widget />}
-        controls={
-          <>
-            <Control />
-            <Control />
-            <Control />
-          </>
-        }
-        caption="Selected Object"
-        actions={<ResetButton onResetCallback={() => undefined} />}
-      />
-    </Container>
+    <Controls
+      {...args}
+      widget={<Widget />}
+      controls={
+        <>
+          <Control />
+          <Control />
+          <Control />
+        </>
+      }
+      caption="Selected Object"
+      actions={<ResetButton onResetCallback={() => undefined} />}
+    />
   );
 };
 

--- a/packages/epo-widget-lib/src/layout/Controls/index.tsx
+++ b/packages/epo-widget-lib/src/layout/Controls/index.tsx
@@ -1,0 +1,36 @@
+import { FunctionComponent, ReactNode } from "react";
+import AspectRatio from "../AspectRatio";
+import * as Styled from "./styles";
+
+interface WidgetControlsProps {
+  widget: ReactNode;
+  controls: ReactNode;
+  actions?: ReactNode;
+  caption?: ReactNode;
+}
+
+const WidgetControls: FunctionComponent<WidgetControlsProps> = ({
+  widget,
+  controls,
+  actions,
+  caption,
+}) => {
+  return (
+    <AspectRatio
+      ratio="landscape"
+      medScreenRatio="landscape"
+      smallScreenRatio="portrait"
+    >
+      <Styled.WidgetLayout>
+        <Styled.WidgetSlot ratio="square">{widget}</Styled.WidgetSlot>
+        <Styled.ControlsSlot>{controls}</Styled.ControlsSlot>
+        <Styled.ActionsSlot>{actions}</Styled.ActionsSlot>
+        <Styled.CaptionSlot>{caption}</Styled.CaptionSlot>
+      </Styled.WidgetLayout>
+    </AspectRatio>
+  );
+};
+
+WidgetControls.displayName = "Layouts.WidgetControls";
+
+export default WidgetControls;

--- a/packages/epo-widget-lib/src/layout/Controls/index.tsx
+++ b/packages/epo-widget-lib/src/layout/Controls/index.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, ReactNode } from "react";
-import AspectRatio from "../AspectRatio";
+import AspectRatio from "@/layout/AspectRatio";
 import * as Styled from "./styles";
 
 interface WidgetControlsProps {
@@ -7,6 +7,7 @@ interface WidgetControlsProps {
   controls: ReactNode;
   actions?: ReactNode;
   caption?: ReactNode;
+  className?: string;
 }
 
 const WidgetControls: FunctionComponent<WidgetControlsProps> = ({
@@ -14,18 +15,27 @@ const WidgetControls: FunctionComponent<WidgetControlsProps> = ({
   controls,
   actions,
   caption,
+  className,
 }) => {
   return (
     <AspectRatio
       ratio="landscape"
       medScreenRatio="landscape"
       smallScreenRatio="portrait"
+      {...{ className }}
     >
       <Styled.WidgetLayout>
-        <Styled.WidgetSlot ratio="square">{widget}</Styled.WidgetSlot>
-        <Styled.ControlsSlot>{controls}</Styled.ControlsSlot>
-        <Styled.ActionsSlot>{actions}</Styled.ActionsSlot>
-        <Styled.CaptionSlot>{caption}</Styled.CaptionSlot>
+        <Styled.InteractionRow>
+          <Styled.Widget>{widget}</Styled.Widget>
+          {caption && (
+            <Styled.PortraitCaption>{caption}</Styled.PortraitCaption>
+          )}
+          {controls && <Styled.Controls>{controls}</Styled.Controls>}
+        </Styled.InteractionRow>
+        {actions && <Styled.Actions>{actions}</Styled.Actions>}
+        {caption && (
+          <Styled.LandscapeCaption>{caption}</Styled.LandscapeCaption>
+        )}
       </Styled.WidgetLayout>
     </AspectRatio>
   );

--- a/packages/epo-widget-lib/src/layout/Controls/styles.ts
+++ b/packages/epo-widget-lib/src/layout/Controls/styles.ts
@@ -1,0 +1,43 @@
+"use client";
+import styled from "styled-components";
+import AspectRatio from "../AspectRatio";
+import { token } from "@rubin-epo/epo-react-lib/styles";
+
+export const WidgetLayout = styled.div`
+  --widget-areas: "widget" "caption" "controls" "actions";
+  --widget-padding: var(--PADDING_SMALL, 20px);
+
+  box-sizing: border-box;
+  display: grid;
+  width: 100%;
+  gap: var(--widget-padding);
+  grid-template-areas: var(--widget-areas);
+  grid-template-columns: 1fr;
+  grid-template-rows: auto;
+  padding: var(--widget-padding);
+
+  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
+    --widget-areas: "controls widget" "actions actions" "caption caption";
+    grid-template-columns: 1fr minmax(200px, max-content);
+    grid-template-rows: auto auto auto;
+  }
+
+  @container (min-width: ${token("BREAK_DESKTOP_SMALL")}) {
+    grid-template-columns: 1fr 1fr;
+  }
+`;
+export const WidgetSlot = styled(AspectRatio)`
+  grid-area: widget;
+`;
+export const ControlsSlot = styled.div`
+  grid-area: controls;
+  display: flex;
+  flex-direction: column;
+  gap: var(--widget-padding);
+`;
+export const ActionsSlot = styled.div`
+  grid-area: actions;
+`;
+export const CaptionSlot = styled.div`
+  grid-area: caption;
+`;

--- a/packages/epo-widget-lib/src/layout/Controls/styles.ts
+++ b/packages/epo-widget-lib/src/layout/Controls/styles.ts
@@ -1,43 +1,75 @@
 "use client";
 import styled from "styled-components";
-import AspectRatio from "../AspectRatio";
 import { token } from "@rubin-epo/epo-react-lib/styles";
 
 export const WidgetLayout = styled.div`
-  --widget-areas: "widget" "caption" "controls" "actions";
-  --widget-padding: var(--PADDING_SMALL, 20px);
+  --widget-padding: calc(var(--PADDING_SMALL, 20px) / 2);
 
   box-sizing: border-box;
-  display: grid;
+  display: flex;
+  flex-direction: column;
   width: 100%;
+  max-height: 100%;
   gap: var(--widget-padding);
-  grid-template-areas: var(--widget-areas);
-  grid-template-columns: 1fr;
-  grid-template-rows: auto;
   padding: var(--widget-padding);
 
-  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
-    --widget-areas: "controls widget" "actions actions" "caption caption";
-    grid-template-columns: 1fr minmax(200px, max-content);
-    grid-template-rows: auto auto auto;
+  @container (min-width: ${token("BREAK_PHABLET_MIN")}) {
+    --widget-padding: var(--PADDING_SMALL, 20px);
   }
 
-  @container (min-width: ${token("BREAK_DESKTOP_SMALL")}) {
-    grid-template-columns: 1fr 1fr;
+  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
+    height: 100%;
   }
 `;
-export const WidgetSlot = styled(AspectRatio)`
-  grid-area: widget;
+
+export const InteractionRow = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  gap: var(--widget-padding);
+
+  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
+    flex-direction: row-reverse;
+  }
 `;
-export const ControlsSlot = styled.div`
-  grid-area: controls;
+
+export const Widget = styled.div`
+  aspect-ratio: 1;
+  max-height: 100%;
+  max-width: 100%;
+  justify-self: center;
+
+  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
+    max-height: unset;
+  }
+`;
+
+export const Controls = styled.div`
   display: flex;
   flex-direction: column;
   gap: var(--widget-padding);
+  width: 100%;
 `;
-export const ActionsSlot = styled.div`
-  grid-area: actions;
+
+export const Actions = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: var(--widget-padding);
+
+  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
+    flex-direction: row;
+  }
 `;
-export const CaptionSlot = styled.div`
-  grid-area: caption;
+
+export const PortraitCaption = styled.div`
+  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
+    display: none;
+  }
+`;
+
+export const LandscapeCaption = styled.div`
+  display: none;
+  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
+    display: block;
+  }
 `;

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/PlotWithCurve.stories.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/PlotWithCurve.stories.tsx
@@ -4,6 +4,7 @@ import { biggerData } from "@/widgets/SourceSelector/mocks";
 import minBy from "lodash/minBy";
 import PlotWithCurve from ".";
 import Container from "@rubin-epo/epo-react-lib/Container";
+import styled from "styled-components";
 
 const meta: Meta<typeof PlotWithCurve> = {
   argTypes: {
@@ -22,6 +23,11 @@ const { alerts } = biggerData;
 
 const peakMjd = (minBy(alerts, ({ magnitude }) => magnitude)?.date || 0) - 0.5;
 
+const InnerContainer = styled.div`
+  display: block;
+  container-type: inline-size;
+`;
+
 const Template: StoryFn<typeof PlotWithCurve> = (args) => {
   const [userMagnitude, setUserMagnitude] = useState(args.userMagnitude);
   const [gaussianWidth, setGaussianWidth] = useState(args.gaussianWidth);
@@ -29,13 +35,15 @@ const Template: StoryFn<typeof PlotWithCurve> = (args) => {
 
   return (
     <Container>
-      <PlotWithCurve
-        {...args}
-        {...{ gaussianWidth, yOffset, userMagnitude }}
-        onGaussianChangeCallback={(value) => setGaussianWidth(value)}
-        onYOffsetChangeCallback={(value) => setYOffset(value)}
-        onUserMagnitudeChangeCallback={(value) => setUserMagnitude(value)}
-      />
+      <InnerContainer>
+        <PlotWithCurve
+          {...args}
+          {...{ gaussianWidth, yOffset, userMagnitude }}
+          onGaussianChangeCallback={(value) => setGaussianWidth(value)}
+          onYOffsetChangeCallback={(value) => setYOffset(value)}
+          onUserMagnitudeChangeCallback={(value) => setUserMagnitude(value)}
+        />
+      </InnerContainer>
     </Container>
   );
 };

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/PlotWithCurve.stories.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/PlotWithCurve.stories.tsx
@@ -3,8 +3,6 @@ import { Meta, StoryFn, StoryObj } from "@storybook/react";
 import { biggerData } from "@/widgets/SourceSelector/mocks";
 import minBy from "lodash/minBy";
 import PlotWithCurve from ".";
-import Container from "@rubin-epo/epo-react-lib/Container";
-import styled from "styled-components";
 
 const meta: Meta<typeof PlotWithCurve> = {
   argTypes: {
@@ -23,28 +21,19 @@ const { alerts } = biggerData;
 
 const peakMjd = (minBy(alerts, ({ magnitude }) => magnitude)?.date || 0) - 0.5;
 
-const InnerContainer = styled.div`
-  display: block;
-  container-type: inline-size;
-`;
-
 const Template: StoryFn<typeof PlotWithCurve> = (args) => {
   const [userMagnitude, setUserMagnitude] = useState(args.userMagnitude);
   const [gaussianWidth, setGaussianWidth] = useState(args.gaussianWidth);
   const [yOffset, setYOffset] = useState(args.yOffset);
 
   return (
-    <Container>
-      <InnerContainer>
-        <PlotWithCurve
-          {...args}
-          {...{ gaussianWidth, yOffset, userMagnitude }}
-          onGaussianChangeCallback={(value) => setGaussianWidth(value)}
-          onYOffsetChangeCallback={(value) => setYOffset(value)}
-          onUserMagnitudeChangeCallback={(value) => setUserMagnitude(value)}
-        />
-      </InnerContainer>
-    </Container>
+    <PlotWithCurve
+      {...args}
+      {...{ gaussianWidth, yOffset, userMagnitude }}
+      onGaussianChangeCallback={(value) => setGaussianWidth(value)}
+      onYOffsetChangeCallback={(value) => setYOffset(value)}
+      onUserMagnitudeChangeCallback={(value) => setUserMagnitude(value)}
+    />
   );
 };
 

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/index.tsx
@@ -11,6 +11,7 @@ import MagnitudeSlider from "./MagnitudeSlider";
 import { PlotWithoutCurveProps } from "../PlotWithoutCurve";
 import * as Styled from "./styles";
 import Viewport from "@/charts/Viewport";
+import Controls from "@/layout/Controls";
 
 interface PlotWithLightCurveProps extends PlotWithoutCurveProps {
   gaussianWidth?: number;
@@ -58,110 +59,116 @@ const PlotWithLightCurve: FunctionComponent<PlotWithLightCurveProps> = ({
   const estimatedPeak = estimateMagnitudeWithOffset(0, gaussianWidth, yOffset);
 
   return (
-    <Styled.Container className={className}>
-      <Plot
-        slider={
-          <MagnitudeSlider
-            magnitude={userMagnitude}
-            onMagnitudeChangeCallback={(v) =>
-              onUserMagnitudeChangeCallback && onUserMagnitudeChangeCallback(v)
+    <>
+      <Controls
+        className={className}
+        widget={
+          <Plot
+            slider={
+              <MagnitudeSlider
+                magnitude={userMagnitude}
+                onMagnitudeChangeCallback={(v) =>
+                  onUserMagnitudeChangeCallback &&
+                  onUserMagnitudeChangeCallback(v)
+                }
+                disabled={isDisplayOnly}
+                {...{ yMin, yMax, estimatedPeak }}
+              />
             }
-            disabled={isDisplayOnly}
-            {...{ yMin, yMax, estimatedPeak }}
+            plotChildren={({
+              xScale,
+              yScale,
+              xDomain,
+              yDomain,
+              xStart,
+              xEnd,
+              yStart,
+              yEnd,
+            }) => (
+              <>
+                <LightCurve
+                  {...{
+                    gaussianWidth,
+                    yOffset,
+                    xDomain,
+                    xScale,
+                    yScale,
+                    yDomain,
+                  }}
+                />
+                <Viewport
+                  x={xStart}
+                  y={yEnd}
+                  outerHeight={yStart - yEnd}
+                  outerWidth={xEnd - xStart}
+                  innerWidth={width}
+                  innerHeight={height}
+                >
+                  <Styled.DM15Display {...{ gaussianWidth }} />
+                </Viewport>
+              </>
+            )}
+            {...{
+              ...props,
+              data,
+              width,
+              height,
+              yMin,
+              yMax,
+            }}
           />
         }
-        plotChildren={({
-          xScale,
-          yScale,
-          xDomain,
-          yDomain,
-          xStart,
-          xEnd,
-          yStart,
-          yEnd,
-        }) => (
-          <>
-            <LightCurve
-              {...{
-                gaussianWidth,
-                yOffset,
-                xDomain,
-                xScale,
-                yScale,
-                yDomain,
-              }}
-            />
-            <Viewport
-              x={xStart}
-              y={yEnd}
-              outerHeight={yStart - yEnd}
-              outerWidth={xEnd - xStart}
-              innerWidth={width}
-              innerHeight={height}
-            >
-              <Styled.DM15Display {...{ gaussianWidth }} />
-            </Viewport>
-          </>
-        )}
-        {...{
-          ...props,
-          data,
-          width,
-          height,
-          yMin,
-          yMax,
-        }}
-      />
-      {data.length > 0 ? <></> : null}
-      {!isDisplayOnly && (
-        <Styled.Controls id={controlsFormId}>
-          <div>
-            <Styled.ControlLabel id={gaussianLabelId}>
-              {t("light_curve.curve.controls.gaussian_width")}
-            </Styled.ControlLabel>
-            <HorizontalSlider
-              label="Gaussian Width"
-              labelledbyId={gaussianLabelId}
-              color="var(--turquoise85, #12726D)"
-              min={defaults.gaussianMin}
-              max={defaults.gaussianMax}
-              step={defaults.gaussianStep}
-              value={gaussianWidth}
-              onChangeCallback={(value) =>
-                typeof value === "number" &&
-                onGaussianChangeCallback &&
-                onGaussianChangeCallback(value)
-              }
-            />
-          </div>
-          <div>
-            <Styled.ControlLabel id={yOffsetLabelId}>
-              {t("light_curve.curve.controls.y_offset")}
-            </Styled.ControlLabel>
-            <HorizontalSlider
-              label="Y Offset"
-              labelledbyId={yOffsetLabelId}
-              color="var(--turquoise85, #12726D)"
-              min={defaults.yOffsetMin}
-              max={defaults.yOffsetMax}
-              step={defaults.yOffsetStep}
-              value={yOffset}
-              onChangeCallback={(value) =>
-                typeof value === "number" &&
-                onYOffsetChangeCallback &&
-                onYOffsetChangeCallback(value)
-              }
-            />
-          </div>
-
-          <Reset onResetCallback={handleReset} />
-        </Styled.Controls>
-      )}
+        controls={
+          !isDisplayOnly && (
+            <Styled.Controls id={controlsFormId}>
+              <div>
+                <Styled.ControlLabel id={gaussianLabelId}>
+                  {t("light_curve.curve.controls.gaussian_width")}
+                </Styled.ControlLabel>
+                <HorizontalSlider
+                  label="Gaussian Width"
+                  labelledbyId={gaussianLabelId}
+                  color="var(--turquoise85, #12726D)"
+                  min={defaults.gaussianMin}
+                  max={defaults.gaussianMax}
+                  step={defaults.gaussianStep}
+                  value={gaussianWidth}
+                  onChangeCallback={(value) =>
+                    typeof value === "number" &&
+                    onGaussianChangeCallback &&
+                    onGaussianChangeCallback(value)
+                  }
+                />
+              </div>
+              <div>
+                <Styled.ControlLabel id={yOffsetLabelId}>
+                  {t("light_curve.curve.controls.y_offset")}
+                </Styled.ControlLabel>
+                <HorizontalSlider
+                  label="Y Offset"
+                  labelledbyId={yOffsetLabelId}
+                  color="var(--turquoise85, #12726D)"
+                  min={defaults.yOffsetMin}
+                  max={defaults.yOffsetMax}
+                  step={defaults.yOffsetStep}
+                  value={yOffset}
+                  onChangeCallback={(value) =>
+                    typeof value === "number" &&
+                    onYOffsetChangeCallback &&
+                    onYOffsetChangeCallback(value)
+                  }
+                />
+              </div>
+            </Styled.Controls>
+          )
+        }
+        actions={!isDisplayOnly && <Reset onResetCallback={handleReset} />}
+      ></Controls>
       <LightCurveLabel
         controlledById={controlsFormId}
         {...{ data, gaussianWidth, yOffset, estimatedPeak }}
       />
-    </Styled.Container>
+    </>
   );
 };
 

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/styles.ts
@@ -2,10 +2,8 @@ import styled from "styled-components";
 import BaseDM15Display from "./DM15Display";
 
 export const Container = styled.div`
-  --light-curve-padding: var(--PADDING_SMALL, 20px);
-
   display: grid;
-  gap: var(--light-curve-padding);
+  gap: var(--widget-padding);
   grid-template-rows: 1fr min-content;
   position: relative;
 `;
@@ -16,8 +14,8 @@ export const PlotContainer = styled.div`
   container-type: inline-size;
   background-color: var(--white, #fff);
   border: 1px solid var(--turquoise55, #009fa1);
-  gap: var(--light-curve-padding);
-  padding: var(--light-curve-padding);
+  gap: var(--widget-padding);
+  padding: var(--widget-padding);
   grid-template-columns: 1fr;
 `;
 
@@ -34,10 +32,10 @@ export const DM15Display = styled(BaseDM15Display)`
 export const Controls = styled.form`
   display: flex;
   flex-direction: column;
-  gap: var(--light-curve-padding);
+  gap: var(--widget-padding);
 `;
 
 export const ControlLabel = styled.span`
   display: block;
-  margin-block-end: var(--light-curve-padding);
+  margin-block-end: var(--widget-padding);
 `;

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithoutCurve/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithoutCurve/index.tsx
@@ -2,6 +2,7 @@ import { FunctionComponent } from "react";
 import { Alert } from "@/types/astro";
 import Plot, { PlotProps } from "../Plot";
 import { useAlertsAsPoints } from "../helpers";
+import AspectRatio from "@/layout/AspectRatio";
 
 export interface PlotWithoutCurveProps extends Omit<PlotProps, "data"> {
   alerts: Array<Alert>;
@@ -16,12 +17,14 @@ const PlotWithoutCurve: FunctionComponent<PlotWithoutCurveProps> = ({
   const data = useAlertsAsPoints(alerts, peakMjd);
 
   return (
-    <Plot
-      {...{
-        ...props,
-        data,
-      }}
-    />
+    <AspectRatio ratio="square">
+      <Plot
+        {...{
+          ...props,
+          data,
+        }}
+      />
+    </AspectRatio>
   );
 };
 

--- a/packages/epo-widget-lib/src/widgets/SourceSelector/SourceSelector.tsx
+++ b/packages/epo-widget-lib/src/widgets/SourceSelector/SourceSelector.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent, ReactNode, useState } from "react";
 import { Alert, Source } from "@/types/astro";
 import { useTranslation } from "react-i18next";
 import IconComposer from "@rubin-epo/epo-react-lib/IconComposer";
-import { Container } from "@/styles/svg";
+import AspectRatio from "@/layout/AspectRatio";
 import * as Styled from "./styles";
 import Message from "./Message";
 import { PointSelector } from ".";
@@ -82,10 +82,7 @@ const SourceSelector: FunctionComponent<SourceSelectorProps> = ({
     : alerts.map(({ image }) => image);
 
   return (
-    <Container
-      style={{ aspectRatio: `${width} / ${height}` }}
-      {...{ className }}
-    >
+    <AspectRatio ratio="square" {...{ className }}>
       {!isDisplayOnly && (
         <Message
           onMessageChangeCallback={handleMessageChange}
@@ -111,7 +108,7 @@ const SourceSelector: FunctionComponent<SourceSelectorProps> = ({
           {...{ width, height, sources, selectedSource }}
         />
       </Styled.BackgroundBlinker>
-    </Container>
+    </AspectRatio>
   );
 };
 

--- a/packages/epo-widget-lib/src/widgets/SupernovaThreeVector/SupernovaThreeVector.stories.tsx
+++ b/packages/epo-widget-lib/src/widgets/SupernovaThreeVector/SupernovaThreeVector.stories.tsx
@@ -1,9 +1,16 @@
 import { Meta, StoryObj } from "@storybook/react";
+import styled from "styled-components";
 import SupernovaThreeVector from ".";
+
+const Container = styled.div`
+  display: block;
+  container-type: inline-size;
+`;
 
 const meta: Meta<typeof SupernovaThreeVector> = {
   argTypes: {},
   component: SupernovaThreeVector,
+  decorators: (Story) => <Container>{Story()}</Container>,
 };
 export default meta;
 

--- a/packages/epo-widget-lib/src/widgets/SupernovaThreeVector/SupernovaThreeVector.stories.tsx
+++ b/packages/epo-widget-lib/src/widgets/SupernovaThreeVector/SupernovaThreeVector.stories.tsx
@@ -1,16 +1,9 @@
 import { Meta, StoryObj } from "@storybook/react";
-import styled from "styled-components";
 import SupernovaThreeVector from ".";
-
-const Container = styled.div`
-  display: block;
-  container-type: inline-size;
-`;
 
 const meta: Meta<typeof SupernovaThreeVector> = {
   argTypes: {},
   component: SupernovaThreeVector,
-  decorators: (Story) => <Container>{Story()}</Container>,
 };
 export default meta;
 

--- a/packages/epo-widget-lib/src/widgets/SupernovaThreeVector/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/SupernovaThreeVector/index.tsx
@@ -84,7 +84,7 @@ const SupernovaThreeVector: FunctionComponent<SupernovaThreeVectorProps> = ({
   }, 0);
 
   return (
-    <Styled.ThreeVectorContainer>
+    <Styled.ThreeVectorContainer ratio="landscape">
       <Styled.ThreeVectorLayout>
         <Styled.HistogramContainer>
           <Styled.ChartTitle>

--- a/packages/epo-widget-lib/src/widgets/SupernovaThreeVector/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/SupernovaThreeVector/styles.ts
@@ -1,10 +1,11 @@
 import styled from "styled-components";
 import { token } from "@rubin-epo/epo-react-lib/styles";
+import AspectRatio from "@/layout/AspectRatio";
 import * as Button from "@/atomic/Button";
 import DistanceHistogram from "./Histogram";
 import BaseSkymap from "./Skymap";
 
-export const ThreeVectorContainer = styled.div`
+export const ThreeVectorContainer = styled(AspectRatio)`
   container-type: inline-size;
 `;
 
@@ -21,7 +22,7 @@ export const ThreeVectorLayout = styled.div`
     "reset";
   gap: var(--three-vector-gap);
 
-  @container (min-width: ${token("BREAK_PHABLET_MIN")}) {
+  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
     grid-template-columns: 1fr 1fr;
     grid-template-rows: 1fr min-content min-content;
     grid-template-areas:

--- a/packages/epo-widget-lib/tsconfig.json
+++ b/packages/epo-widget-lib/tsconfig.json
@@ -22,6 +22,7 @@
       "@/atomic/*": ["src/atomic/*"],
       "@/charts/*": ["src/charts/*"],
       "@/hooks/*": ["src/hooks/*"],
+      "@/layout/*": ["src/layout/*"],
       "@/lib/*": ["src/lib/*"],
       "@/storybook/*": [".storybook/*"],
       "@/styles/*": ["src/styles/*"],


### PR DESCRIPTION
## What this change does

This adds two important helpers to the widgets library: an aspect ratio container that enforces either a square, portrait, or landscape layout, and a generic "controls" container modelled after Color Tool that has spots for a widget display, interactive controls, actions (reset), and a caption.

Importantly, the aspect ratio container also has height enforcement based on the screen height (100vh) or an overriding variable that can be used to calculator a value like `100vh - nav height - pager height` to fine tune the final size.

## Testing

Check out the new Storybook stories, these features have also been added to Source Selector, Supernovae Three Vector, and the Light Curve Plots to start. Retrofitting Color Tool will need more in-depth dev along with the other widgets.

## Screenshots (optional)

### Before:

### After:
