### PR TITLE
[C] replace react-uid with useId

### DIFF
--- a/packages/epo-react-lib/CHANGELOG.md
+++ b/packages/epo-react-lib/CHANGELOG.md
@@ -86,3 +86,7 @@
 # 2.0.24
 
 - update `@headlessui/react` to 2.x
+
+# 2.0.25
+
+- replace `react-uid` with `useId`

--- a/packages/epo-react-lib/package.json
+++ b/packages/epo-react-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rubin-epo/epo-react-lib",
   "description": "Rubin Observatory Education & Public Outreach team React UI library.",
-  "version": "2.0.24",
+  "version": "2.0.25",
   "author": "Rubin EPO",
   "license": "MIT",
   "homepage": "https://lsst-epo.github.io/epo-react-lib",
@@ -68,7 +68,6 @@
     "react-player": "^2.14.1",
     "react-share": "^4.4.1",
     "react-slider": "^2.0.6",
-    "react-uid": "^2.3.2",
     "styled-components": "^6.1.1"
   },
   "devDependencies": {

--- a/packages/epo-react-lib/src/hooks/useCarousel.ts
+++ b/packages/epo-react-lib/src/hooks/useCarousel.ts
@@ -1,6 +1,5 @@
 import { CarouselConfig, CarouselOptions } from "@/types/carousel";
-import { useState, useEffect, useRef, useCallback } from "react";
-import { useUID } from "react-uid";
+import { useState, useEffect, useRef, useCallback, useId } from "react";
 
 const DEFAULT_OPTIONS: Required<CarouselOptions> = {
   selectedAttraction: 0.075,
@@ -38,7 +37,7 @@ export default function useCarousel(options: CarouselOptions): CarouselConfig {
     }
   }, []);
 
-  const uid = useUID();
+  const uid = useId();
 
   const mergedOptions: Required<CarouselOptions> = Object.assign(
     {},

--- a/packages/epo-react-lib/vite.config.ts
+++ b/packages/epo-react-lib/vite.config.ts
@@ -131,7 +131,6 @@ export default defineConfig({
         "react-player/youtube",
         "react-share",
         "react-slider",
-        "react-uid",
         "styled-components",
       ],
       output: {

--- a/packages/epo-widget-lib/vite.config.ts
+++ b/packages/epo-widget-lib/vite.config.ts
@@ -97,7 +97,6 @@ export default defineConfig({
         "react-player/youtube",
         "react-share",
         "react-slider",
-        "react-uid",
         "skia-canvas",
         "styled-components",
         "use-resize-observer",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10607,13 +10607,6 @@ react-style-singleton@^2.2.1:
     invariant "^2.2.4"
     tslib "^2.0.0"
 
-react-uid@^2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/react-uid/-/react-uid-2.3.3.tgz#6a485ccc868555997f3506c6db97a3e735d97adf"
-  integrity sha512-iNpDovcb9qBpBTo8iUgqRSQOS8GV3bWoNaTaUptHkXtAooXSo0OWe7vN6TqqB8x3x0bNBbQx96kkmSltQ5h9kQ==
-  dependencies:
-    tslib "^2.0.0"
-
 react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"


### PR DESCRIPTION
## What this change does

Replace the `react-uid` package with the built-in `useId` hook

Resolves #178 
