### PR TITLE
[F] fix: grid passes props to DOM

### DIFF
--- a/packages/epo-react-lib/CHANGELOG.md
+++ b/packages/epo-react-lib/CHANGELOG.md
@@ -102,3 +102,7 @@
 # 2.0.30
 
 - re-organize dependencies
+
+# 2.0.31
+
+- fix: `Grid` component passes props to DOM

--- a/packages/epo-react-lib/package.json
+++ b/packages/epo-react-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rubin-epo/epo-react-lib",
   "description": "Rubin Observatory Education & Public Outreach team React UI library.",
-  "version": "2.0.30",
+  "version": "2.0.31",
   "author": "Rubin EPO",
   "license": "MIT",
   "homepage": "https://lsst-epo.github.io/epo-react-lib",

--- a/packages/epo-react-lib/src/layout/Grid/Grid.tsx
+++ b/packages/epo-react-lib/src/layout/Grid/Grid.tsx
@@ -1,18 +1,29 @@
-import { FunctionComponent, ReactNode } from "react";
+import { FunctionComponent, PropsWithChildren } from "react";
 import * as Styled from "./styles";
 
-interface GridProps extends Partial<Styled.GridProps> {
-  children: ReactNode;
+export interface GridProps {
+  columns: number;
+  tablet: number;
+  showFeature: boolean;
 }
 
-const Grid: FunctionComponent<GridProps> = ({
+const Grid: FunctionComponent<PropsWithChildren<GridProps>> = ({
   children,
   showFeature = false,
   columns = 3,
   tablet = 1,
 }) => {
   return (
-    <Styled.Grid {...{ columns, showFeature, tablet }}>{children}</Styled.Grid>
+    <Styled.Grid
+      data-show-feature={showFeature}
+      style={{
+        "--count-columns-grid": columns,
+        "--count-columns-grid-tablet": tablet,
+      }}
+      {...{ columns }}
+    >
+      {children}
+    </Styled.Grid>
   );
 };
 

--- a/packages/epo-react-lib/src/layout/Grid/styles.ts
+++ b/packages/epo-react-lib/src/layout/Grid/styles.ts
@@ -1,25 +1,22 @@
 import styled from "styled-components";
-import { layoutGrid } from "@/styles/utils";
-import { BREAK_PHABLET_MIN, BREAK_TABLET } from "@/styles/abstracts";
+import { layoutGrid, token } from "@/styles/utils";
 
-export interface GridProps {
-  columns: number;
-  tablet: number;
-  showFeature: boolean;
-}
+const tabletMin = token("BREAK_PHABLET_MIN");
+const tabletMax = token("BREAK_TABLET");
 
-export const Grid = styled.ul<GridProps>`
-  ${({ columns, tablet }: GridProps) => `${layoutGrid(columns)}
-    @media (min-width: ${BREAK_PHABLET_MIN}) and (max-width: ${BREAK_TABLET}) {
-      grid-template-columns: repeat(${tablet}, 1fr);
-      > * {grid-column: span 1;}
-    }    
-  `}
+export const Grid = styled.ul`
+  ${layoutGrid("var(--count-columns-grid)")}
 
-  ${({ showFeature }: GridProps) =>
-    showFeature
-      ? `    > :first-child {
+  @media screen and (min-width: ${tabletMin}) and (max-width: ${tabletMax}) {
+    grid-template-columns: repeat(var(--count-columns-grid-tablet), 1fr);
+    > * {
+      grid-column: span 1;
+    }
+  }
+
+  &[data-show-feature="true"] {
+    > :first-child {
       grid-column: 1 / -1;
-      }`
-      : ``}
+    }
+  }
 `;

--- a/packages/epo-react-lib/src/styles/utils/index.ts
+++ b/packages/epo-react-lib/src/styles/utils/index.ts
@@ -36,7 +36,7 @@ export const containerRegular = () => protoContainer(tokens.CONTAINER_REGULAR);
 export const containerNarrow = () => protoContainer(tokens.CONTAINER_NARROW);
 
 export const layoutGrid = (
-  columns = 3,
+  columns: number | string = 3,
   gapDesktop = tokens.PADDING_SMALL,
   gapMobile = tokens.PADDING_SMALL,
   breakPoint = tokens.BREAK_TABLET
@@ -61,7 +61,8 @@ export const encodeColor = (string: string) => {
 };
 
 export const needsDarkColor = (hexColor: string) => {
-  const color = hexColor.charAt(0) === "#" ? hexColor.substring(1, 7) : hexColor;
+  const color =
+    hexColor.charAt(0) === "#" ? hexColor.substring(1, 7) : hexColor;
   const r = parseInt(color.substring(0, 2), 16); // hexToR
   const g = parseInt(color.substring(2, 4), 16); // hexToG
   const b = parseInt(color.substring(4, 6), 16); // hexToB
@@ -116,7 +117,7 @@ export function token(which: unknown): unknown {
   if (typeof which === "string") {
     return tokens[which as StyleToken];
   } else if (Array.isArray(which)) {
-    let obj = which.reduce(
+    const obj = which.reduce(
       (result: Record<StyleToken, string>, item: StyleToken) => {
         result[item] = tokens[item];
         return result;


### PR DESCRIPTION
## What this change does

Refactor `Grid` component to use CSS variables instead of passing props to styled components
