### PR TITLE
[B] ResponsiveImage leaks styles to DOM

### DIFF
--- a/packages/epo-react-lib/CHANGELOG.md
+++ b/packages/epo-react-lib/CHANGELOG.md
@@ -106,3 +106,7 @@
 # 2.0.31
 
 - fix: `Grid` component passes props to DOM
+
+# 2.0.32
+
+- fix: `ResponsiveImage` leaks styles to DOM

--- a/packages/epo-react-lib/src/atomic/ResponsiveImage/ResponsiveImage.stories.tsx
+++ b/packages/epo-react-lib/src/atomic/ResponsiveImage/ResponsiveImage.stories.tsx
@@ -1,9 +1,9 @@
-import { ComponentMeta, ComponentStoryObj } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import { className } from "@/storybook/utilities/argTypes";
 
 import ResponsiveImage from ".";
 
-const meta: ComponentMeta<typeof ResponsiveImage> = {
+const meta: Meta<typeof ResponsiveImage> = {
   component: ResponsiveImage,
   argTypes: {
     image: {
@@ -21,7 +21,7 @@ const meta: ComponentMeta<typeof ResponsiveImage> = {
 };
 export default meta;
 
-export const Primary: ComponentStoryObj<typeof ResponsiveImage> = {
+export const Primary: StoryObj<typeof ResponsiveImage> = {
   args: {
     image: {
       altText: "A placeholder image",

--- a/packages/epo-react-lib/src/atomic/ResponsiveImage/ResponsiveImage.tsx
+++ b/packages/epo-react-lib/src/atomic/ResponsiveImage/ResponsiveImage.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from "react";
-import Image, { ImageProps } from "../Image";
+import { ImageProps } from "../Image";
 import * as Styled from "./styles";
 
 interface ResponsiveImageProps extends ImageProps {
@@ -13,14 +13,14 @@ const ResponsiveImage: FunctionComponent<ResponsiveImageProps> = ({
   title,
   ...props
 }) => {
-  const aspectRatio = ratio.split(":").map(Number);
+  const aspectRatio = ratio.includes(":") ? ratio.replace(":", "/") : ratio;
 
   return (
     <Styled.ResponsiveImageContainer
-      $aspectRatio={aspectRatio}
+      style={{ "--aspect-ratio": aspectRatio }}
       className={className}
     >
-      <Image image={image} title={title} {...props} />
+      <Styled.Image image={image} title={title} {...props} />
     </Styled.ResponsiveImageContainer>
   );
 };

--- a/packages/epo-react-lib/src/atomic/ResponsiveImage/styles.ts
+++ b/packages/epo-react-lib/src/atomic/ResponsiveImage/styles.ts
@@ -1,33 +1,21 @@
 import styled from "styled-components";
+import BaseImage from "../Image";
 
-interface ResponsiveImageContainerProps {
-  $aspectRatio: number[];
-}
-
-export const ResponsiveImageContainer = styled.div<ResponsiveImageContainerProps>`
+export const ResponsiveImageContainer = styled.div`
   position: relative;
   overflow: hidden;
   width: 100%;
-  padding-top: ${({ $aspectRatio }: ResponsiveImageContainerProps) =>
-    $aspectRatio.length > 1
-      ? `${($aspectRatio[1] / $aspectRatio[0]) * 100}%}`
-      : "100%"};
+  aspect-ratio: var(--aspect-ratio);
+`;
 
-  @supports (aspect-ratio: auto) {
-    padding-top: 0;
-    aspect-ratio: ${({ $aspectRatio }: ResponsiveImageContainerProps) =>
-      `${$aspectRatio[0]} / ${$aspectRatio[1]}`};
-  }
-
-  img {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: auto;
-    height: auto;
-    min-width: 100%;
-    min-height: 100%;
-    object-fit: cover;
-  }
+export const Image = styled(BaseImage)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: auto;
+  height: auto;
+  min-width: 100%;
+  min-height: 100%;
+  object-fit: cover;
 `;


### PR DESCRIPTION
Resolves #222 

Fix `ResponsiveImage` leaking styles to the rest of the DOM by restyling child component instead of adding `img` targeted CSS