### PR TITLE
Use media orientation

### DIFF
--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -94,7 +94,7 @@
     "react-i18next": "^12.0.0 || ^13.0.0"
   },
   "dependencies": {
-    "@rubin-epo/epo-react-lib": "~2.0",
+    "@rubin-epo/epo-react-lib": "^2.0.32",
     "context-filter-polyfill": "^0.3.6",
     "d3-array": "^3.2.4",
     "d3-geo": "^3.1.0",

--- a/packages/epo-widget-lib/src/layout/AspectRatio/AspectRatio.stories.tsx
+++ b/packages/epo-widget-lib/src/layout/AspectRatio/AspectRatio.stories.tsx
@@ -2,26 +2,10 @@ import { Meta, StoryFn, StoryObj } from "@storybook/react";
 import styled from "styled-components";
 import AspectRatio from ".";
 
-const options = {
-  Square: "square",
-  Landscape: "landscape",
-  Portrait: "portrait",
-  None: undefined,
-};
-
 const meta: Meta<typeof AspectRatio> = {
   argTypes: {
     ratio: {
-      control: "select",
-      options,
-    },
-    medScreenRatio: {
-      control: "select",
-      options,
-    },
-    smallScreenRatio: {
-      control: "select",
-      options,
+      control: "object",
     },
   },
   component: AspectRatio,
@@ -45,7 +29,11 @@ const Template: StoryFn<typeof AspectRatio> = (args) => {
 
 export const Primary: StoryObj<typeof AspectRatio> = Template.bind({});
 Primary.args = {
-  ratio: "landscape",
-  medScreenRatio: "square",
-  smallScreenRatio: "portrait",
+  ratio: 1,
+};
+export const MultipleOrientations: StoryObj<typeof AspectRatio> = Template.bind(
+  {}
+);
+MultipleOrientations.args = {
+  ratio: { landscape: 3 / 2, portrait: 2 / 3 },
 };

--- a/packages/epo-widget-lib/src/layout/AspectRatio/index.tsx
+++ b/packages/epo-widget-lib/src/layout/AspectRatio/index.tsx
@@ -1,20 +1,12 @@
 import { FunctionComponent, PropsWithChildren } from "react";
 import * as Styled from "./styles";
 
-type AspectRatio = "square" | "portrait" | "landscape";
+export type Ratios = Record<"landscape" | "portrait", number>;
 
 export interface AspectRatioProps {
-  ratio: AspectRatio;
-  medScreenRatio?: AspectRatio;
-  smallScreenRatio?: AspectRatio;
+  ratio: number | Ratios;
   className?: string;
 }
-
-const ratios: Record<AspectRatio, number> = {
-  square: 1,
-  portrait: parseFloat((9 / 16).toFixed(3)),
-  landscape: parseFloat((16 / 9).toFixed(3)),
-};
 
 /**
  * Wrapper component for widgets that can accept up to 3 target ratios for
@@ -26,19 +18,20 @@ const ratios: Record<AspectRatio, number> = {
  */
 const AspectRatio: FunctionComponent<PropsWithChildren<AspectRatioProps>> = ({
   ratio,
-  medScreenRatio = ratio,
-  smallScreenRatio = ratio,
   children,
   className,
 }) => {
-  const cssVariables = {
-    "--aspect-large-ratio": ratios[ratio],
-    "--aspect-med-ratio": ratios[medScreenRatio],
-    "--aspect-small-ratio": ratios[smallScreenRatio],
-  };
+  const portraitRatio = typeof ratio === "object" ? ratio.portrait : ratio;
+  const landscapeRatio = typeof ratio === "object" ? ratio.landscape : ratio;
 
   return (
-    <Styled.AspectRatio style={cssVariables} className={className}>
+    <Styled.AspectRatio
+      style={{
+        "--size-aspect-ratio-portrait": portraitRatio,
+        "--size-aspect-ratio-landscape": landscapeRatio,
+      }}
+      className={className}
+    >
       {children}
     </Styled.AspectRatio>
   );

--- a/packages/epo-widget-lib/src/layout/AspectRatio/styles.ts
+++ b/packages/epo-widget-lib/src/layout/AspectRatio/styles.ts
@@ -1,27 +1,18 @@
 "use client";
 import styled from "styled-components";
-import { token } from "@rubin-epo/epo-react-lib/styles";
-import Loader from "@/atomic/Loader";
 
 export const AspectRatio = styled.div`
-  --aspect-ratio: var(--aspect-small-ratio, 1);
-
-  aspect-ratio: var(--aspect-ratio);
+  aspect-ratio: var(--size-aspect-ratio);
   position: relative;
-  width: calc(var(--widget-max-height, 100vh) * var(--aspect-ratio));
+  width: calc(var(--widget-max-height, 100vh) * var(--size-aspect-ratio));
   max-height: var(--widget-max-height, 100vh);
   max-width: 100%;
 
-  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
-    --aspect-ratio: var(--aspect-med-ratio, 1);
+  @media (orientation: landscape) {
+    --size-aspect-ratio: var(--size-aspect-ratio-landscape, 1);
   }
-  @container (min-width: ${token("BREAK_DESKTOP_SMALL")}) {
-    --aspect-ratio: var(--aspect-large-ratio, 1);
-  }
-`;
 
-export const StackedLoader = styled(Loader)`
-  position: absolute;
-  top: 0;
-  left: 0;
+  @media (orientation: portrait) {
+    --size-aspect-ratio: var(--size-aspect-ratio-portrait, 1);
+  }
 `;

--- a/packages/epo-widget-lib/src/layout/Controls/index.tsx
+++ b/packages/epo-widget-lib/src/layout/Controls/index.tsx
@@ -1,10 +1,11 @@
 import { FunctionComponent, ReactNode } from "react";
-import AspectRatio from "@/layout/AspectRatio";
+import AspectRatio, { Ratios } from "@/layout/AspectRatio";
 import * as Styled from "./styles";
 
 interface WidgetControlsProps {
   widget: ReactNode;
   controls: ReactNode;
+  ratio?: Ratios;
   controlsId?: string;
   actions?: ReactNode;
   caption?: ReactNode;
@@ -15,6 +16,7 @@ interface WidgetControlsProps {
 
 const WidgetControls: FunctionComponent<WidgetControlsProps> = ({
   widget,
+  ratio = { landscape: 16 / 9, portrait: 9 / 16 },
   controls,
   actions,
   caption,
@@ -25,19 +27,14 @@ const WidgetControls: FunctionComponent<WidgetControlsProps> = ({
 }) => {
   if (isDisplayOnly)
     return (
-      <AspectRatio ratio="square">
+      <AspectRatio ratio={1}>
         {widget}
         {isLoading && <Styled.StackedLoader />}
       </AspectRatio>
     );
 
   return (
-    <AspectRatio
-      ratio="landscape"
-      medScreenRatio="landscape"
-      smallScreenRatio="portrait"
-      {...{ className }}
-    >
+    <AspectRatio {...{ className, ratio }}>
       <Styled.WidgetLayout>
         <Styled.InteractionRow>
           <Styled.Widget>

--- a/packages/epo-widget-lib/src/layout/Controls/styles.ts
+++ b/packages/epo-widget-lib/src/layout/Controls/styles.ts
@@ -11,9 +11,8 @@ export const WidgetLayout = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-height: 100%;
+  height: 100%;
   gap: var(--widget-gap);
-  overflow-y: auto;
 
   @container (min-width: ${token("BREAK_PHABLET_MIN")}) {
     --default-widget-padding: var(--PADDING_SMALL, 20px);
@@ -28,8 +27,9 @@ export const WidgetLayout = styled.div`
 export const InteractionRow = styled.div`
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
+  flex: 1 1;
   gap: var(--widget-gap);
+  min-height: 0;
 
   @media (orientation: landscape) {
     flex-direction: row-reverse;
@@ -38,7 +38,7 @@ export const InteractionRow = styled.div`
 
 export const Widget = styled.div`
   aspect-ratio: 1;
-  flex: 1 1 auto;
+  flex: 1 0 auto;
   max-height: 100%;
   max-width: 100%;
   justify-self: center;
@@ -55,6 +55,9 @@ export const Controls = styled.form`
   flex-direction: column;
   gap: var(--widget-gap);
   flex: 0 1 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-inline: 2px;
 `;
 
 export const Actions = styled.div`

--- a/packages/epo-widget-lib/src/layout/Controls/styles.ts
+++ b/packages/epo-widget-lib/src/layout/Controls/styles.ts
@@ -19,7 +19,7 @@ export const WidgetLayout = styled.div`
     --default-widget-padding: var(--PADDING_SMALL, 20px);
   }
 
-  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
+  @media (orientation: landscape) {
     height: 100%;
     overflow-y: initial;
   }
@@ -31,7 +31,7 @@ export const InteractionRow = styled.div`
   flex-grow: 1;
   gap: var(--widget-gap);
 
-  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
+  @media (orientation: landscape) {
     flex-direction: row-reverse;
   }
 `;
@@ -44,7 +44,7 @@ export const Widget = styled.div`
   justify-self: center;
   position: relative;
 
-  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
+  @media (orientation: landscape) {
     max-height: unset;
     height: 100%;
   }
@@ -63,15 +63,14 @@ export const Actions = styled.div`
 `;
 
 export const PortraitCaption = styled.div`
-  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
+  @media (orientation: landscape) {
     display: none;
   }
 `;
 
 export const LandscapeCaption = styled.div`
-  display: none;
-  @container (min-width: ${token("BREAK_LARGE_TABLET")}) {
-    display: block;
+  @media (orientation: portrait) {
+    display: none;
   }
 `;
 

--- a/packages/epo-widget-lib/src/widgets/CameraFilter/CameraFilter.tsx
+++ b/packages/epo-widget-lib/src/widgets/CameraFilter/CameraFilter.tsx
@@ -39,7 +39,7 @@ const CameraFilter: FunctionComponent = () => {
   const activeFilter = filters.find(({ band }) => band === activeFilterBand);
 
   return (
-    <Styled.FilterWrapper ratio="landscape" smallScreenRatio="square">
+    <Styled.FilterWrapper ratio={5 / 4}>
       <Styled.FilterContainer ref={ref}>
         <Styled.FilterTitle>{t("camera_filter.title")}</Styled.FilterTitle>
         {isCondensed && (

--- a/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/ColorTool.tsx
@@ -95,7 +95,7 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
 
   if (isDisplayOnly) {
     return (
-      <AspectRatio ratio="square">
+      <AspectRatio ratio={1}>
         <ImageComposite
           ref={imageRef}
           isDisplayOnly
@@ -138,6 +138,7 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
 
   return (
     <Styled.WidgetLayout
+      ratio={{ landscape: 3 / 2, portrait: 9 / 16 }}
       widget={
         <ImageComposite
           ref={imageRef}

--- a/packages/epo-widget-lib/src/widgets/FilterTool/FilterTool.tsx
+++ b/packages/epo-widget-lib/src/widgets/FilterTool/FilterTool.tsx
@@ -100,7 +100,7 @@ const FilterTool: FunctionComponent<FilterToolProps> = ({
   const isNoneSelected = selectedColor === "none";
 
   return (
-    <Styled.Wrapper ratio="landscape">
+    <Styled.Wrapper ratio={3 / 2}>
       <Styled.PrismSVG
         version="1.1"
         viewBox="0 0 1551.6 736.7"

--- a/packages/epo-widget-lib/src/widgets/FilterTool/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/FilterTool/styles.ts
@@ -2,6 +2,9 @@ import styled from "styled-components";
 import AspectRatio from "@/layout/AspectRatio";
 
 export const Wrapper = styled(AspectRatio)`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   background-color: var(--black, #000);
 `;
 

--- a/packages/epo-widget-lib/src/widgets/IsochronePlot/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/IsochronePlot/index.tsx
@@ -206,6 +206,7 @@ const IsochronePlot: FunctionComponent<Props> = ({
 
   return (
     <WidgetControls
+      ratio={{ portrait: 2 / 3, landscape: 3 / 2 }}
       widget={Widget}
       controls={
         <Controls

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/index.tsx
@@ -144,7 +144,7 @@ const PlotWithLightCurve: FunctionComponent<PlotWithLightCurveProps> = ({
     <>
       <Controls
         {...{ className, isDisplayOnly }}
-        ratio={{ landscape: 5 / 4, portrait: 4 / 7 }}
+        ratio={{ landscape: 3 / 2, portrait: 2 / 3 }}
         widget={Widget}
         controls={
           <>

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithCurve/index.tsx
@@ -144,6 +144,7 @@ const PlotWithLightCurve: FunctionComponent<PlotWithLightCurveProps> = ({
     <>
       <Controls
         {...{ className, isDisplayOnly }}
+        ratio={{ landscape: 5 / 4, portrait: 4 / 7 }}
         widget={Widget}
         controls={
           <>

--- a/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithoutCurve/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/LightCurvePlot/PlotWithoutCurve/index.tsx
@@ -17,7 +17,7 @@ const PlotWithoutCurve: FunctionComponent<PlotWithoutCurveProps> = ({
   const data = useAlertsAsPoints(alerts, peakMjd);
 
   return (
-    <AspectRatio ratio="square">
+    <AspectRatio ratio={1}>
       <Plot
         {...{
           ...props,

--- a/packages/epo-widget-lib/src/widgets/SourceSelector/SourceSelector.tsx
+++ b/packages/epo-widget-lib/src/widgets/SourceSelector/SourceSelector.tsx
@@ -108,7 +108,7 @@ const SourceSelector: FunctionComponent<SourceSelectorProps> = ({
     : alerts.map(({ image }) => image);
 
   return (
-    <AspectRatio ratio="square" {...{ className }}>
+    <AspectRatio ratio={1} {...{ className }}>
       {!isDisplayOnly && (
         <Message
           onMessageChangeCallback={handleMessageChange}

--- a/packages/epo-widget-lib/src/widgets/SupernovaThreeVector/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/SupernovaThreeVector/index.tsx
@@ -82,7 +82,7 @@ const SupernovaThreeVector: FunctionComponent<SupernovaThreeVectorProps> = ({
   }, 0);
 
   return (
-    <Styled.ThreeVectorContainer ratio="landscape" smallScreenRatio="portrait">
+    <Styled.ThreeVectorContainer ratio={{ landscape: 3 / 2, portrait: 2 / 3 }}>
       <Styled.ThreeVectorLayout>
         <Styled.HistogramContainer>
           <Styled.ChartTitle>

--- a/packages/epo-widget-lib/src/widgets/SupernovaThreeVector/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/SupernovaThreeVector/index.tsx
@@ -82,7 +82,7 @@ const SupernovaThreeVector: FunctionComponent<SupernovaThreeVectorProps> = ({
   }, 0);
 
   return (
-    <Styled.ThreeVectorContainer ratio={{ landscape: 3 / 2, portrait: 2 / 3 }}>
+    <Styled.ThreeVectorContainer ratio={{ landscape: 3 / 2, portrait: 9 / 16 }}>
       <Styled.ThreeVectorLayout>
         <Styled.HistogramContainer>
           <Styled.ChartTitle>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3464,6 +3464,21 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
+"@rubin-epo/epo-react-lib@^2.0.32":
+  version "2.0.32"
+  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-react-lib/-/epo-react-lib-2.0.32.tgz#ef2146ccc150cc37853584e9f191a22ac1f045eb"
+  integrity sha512-ACT0GNVQiSIWK01/38xM4SNsKU40gs2MsDkbtr7kbmb8z+RsKla5sU2J4DcdUJFmd7muAhgxuYzSGse23Nc57g==
+  dependencies:
+    "@castiron/style-mixins" "^1.0.6"
+    "@headlessui/react" "^2.0.3"
+    flickity "^3.0.0"
+    focus-trap "^7.4.2"
+    lodash "^4.17.21"
+    react-player "^2.14.1"
+    react-share "^4.4.1"
+    react-slider "^2.0.6"
+    styled-components "^6.1.1"
+
 "@rushstack/eslint-patch@^1.10.1":
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.10.2.tgz#053f1540703faa81dea2966b768ee5581c66aeda"


### PR DESCRIPTION
## What this change does

Instead of using screen size, which can confuse smaller laptops for tablets, use media orientation to determine which aspect ratio to present to devices. Also implement first round of aspect ratio sizing
