### PR TITLE
refactor: remove src from source

### DIFF
--- a/packages/epo-react-lib/src/atomic/Picture/Picture.stories.tsx
+++ b/packages/epo-react-lib/src/atomic/Picture/Picture.stories.tsx
@@ -50,7 +50,6 @@ Primary.args = {
   },
   sources: [
     {
-      src: "https://rubin.canto.com/direct/image/9u18e5a58t17t372gj0eepo80c/A9NWRljpJ8XF4R4q91q1d0ubEuA/original?content-type=image%2Fjpeg&name=Eye-Bayer+filter+comparison+V2-100.jpg",
       srcSet: generateCantoSrcSet(
         "https://rubin.canto.com/direct/image/9u18e5a58t17t372gj0eepo80c/DN9LDOXn0jmgoGTOJP8agB55AHE/m800/",
         823

--- a/packages/epo-react-lib/src/atomic/Picture/index.tsx
+++ b/packages/epo-react-lib/src/atomic/Picture/index.tsx
@@ -8,8 +8,7 @@ type AlternateSource = {
   width: number;
   height?: number;
   mediaCondition?: string;
-  srcSet: Array<srcType>;
-  src: string;
+  srcSet: string | Array<srcType>;
 };
 
 export type PictureProps = {
@@ -25,13 +24,15 @@ const Picture: FunctionComponent<PictureProps> = ({
 }) => {
   return (
     <picture {...{ className }}>
-      {sources.map(({ src, srcSet, mediaCondition, width, ...props }, i) => {
+      {sources.map(({ srcSet, mediaCondition, ...props }, i) => {
         return (
           <source
             key={i}
-            srcSet={stringifySrcSet([...srcSet, { src, size: width }])}
+            srcSet={
+              Array.isArray(srcSet) ? stringifySrcSet([...srcSet]) : srcSet
+            }
             media={mediaCondition}
-            {...{ width, ...props }}
+            {...{ ...props }}
           />
         );
       })}


### PR DESCRIPTION
Per HTML spec, `src` is not allowed as an attribute of `<source>` elements when the parent is `picture`