### PR TITLE
Create types for orbital sim data structures

### DIFF
--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/OrbitalSimContext.types.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/OrbitalSimContext.types.ts
@@ -1,0 +1,50 @@
+import { ReactNode } from "react";
+
+export interface OrbitalSimProviderProps {
+    children: ReactNode,
+    orbitData: Orbits
+}
+
+export type OrbitalSimContextValues = {
+  orbits: Orbits;
+  setOrbits: React.Dispatch<React.SetStateAction<Orbits>>;
+  observations: Observation[];
+  setObservations: React.Dispatch<React.SetStateAction<Observation[]>>;
+  updateActiveObservation: (activeId: string) => void;
+};
+
+export type Observation = {
+    id: string,
+    label: string,
+    interactable: boolean,
+    isActive: boolean,
+    position: number,
+    isAnswer?: boolean
+}
+
+export type Neo = {
+    a: number,
+    e: number,
+    i:number,
+    Peri: number,
+    Node: number
+}
+
+export type DetailsRow = {
+    rowTitle: string,
+    rowContent: string | TrustedHTML
+}
+
+export type Orbits = {
+    neos: Neo[] | null,
+    activeNeo: Neo | null,
+    observations: Observation[],
+    paused: boolean,
+    pov: string | null,
+    defaultZoom: number | null,
+    potentialOrbits: boolean,
+    noDetails: boolean,
+    detailsRows: DetailsRow[] | null,
+    refObjs: string[] | null,
+    noControls: boolean
+}

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
@@ -1,46 +1,7 @@
 // export { OrbitalSimProvider, OrbitalSimContext, useOrbitalSimContext } from "./OrbitalSimContext";
 
 import { createContext, useContext, ReactNode, useState, useEffect, useMemo } from "react";
-
-interface OrbitalSimProviderProps {
-    children: ReactNode,
-    orbitData: Orbits
-}
-
-type OrbitalSimContextValues = {
-  orbits: Orbits;
-  setOrbits: React.Dispatch<React.SetStateAction<Orbits>>;
-  observations: Observation[];
-  setObservations: React.Dispatch<React.SetStateAction<Observation[]>>;
-  updateActiveObservation: (activeId: string) => void;
-};
-
-type Observation = {
-    id: string,
-    label: string,
-    interactable: boolean,
-    isActive: boolean,
-    position: number,
-    isAnswer?: boolean
-}
-
-type Orbits = {
-    neos: any,
-    activeNeo: any,
-    observations: Observation[],
-    activeObs: any,
-    selectionCallback: any,
-    paused: any,
-    pov: any,
-    defaultZoom: any,
-    potentialOrbits: any,
-    noDetails: any,
-    detailsSet: any,
-    detailsRows: any,
-    refObjs: any,
-    noLabels: any,
-    noControls:boolean
-}
+import type {OrbitalSimContextValues, OrbitalSimProviderProps, Orbits, Observation } from './OrbitalSimContext.types.ts'
 
 export const OrbitalSimContext = createContext<OrbitalSimContextValues | null>(null);
 
@@ -85,17 +46,13 @@ export function OrbitalSimProvider({ children, orbitData }: OrbitalSimProviderPr
         neos: null,
         activeNeo: null,
         observations: [],
-        activeObs: null,
-        selectionCallback: null,
-        paused: null,
+        paused: false,
         pov: null,
         defaultZoom: null,
-        potentialOrbits: null,
-        noDetails: null,
-        detailsSet: null,
+        potentialOrbits: false,
+        noDetails: false,
         detailsRows: null,
         refObjs: null,
-        noLabels: null,
         noControls: false
     })
     const [ observations, setObservations ] = useState<Observation[]>(() => 


### PR DESCRIPTION
## What this change does

This PR defines the placeholder types in the orbital sim's context file, removes those that aren't in use, and moves the type definitions from the context file to a dedicated types file.
Resolves #372 

## Notes for reviewers

Detailed notes about the type changes and what was removed can be found in the [A&D](https://docs.google.com/document/d/1gCipRNK4FoF6Jq7dNfdXFVVzMxeM74By5n2dvwSgRn4/edit?usp=sharing)

## Testing

Running `npx tsc --noEmit` in `packages/epo-widget-lib` directory will confirm that no TypeScript errors were introduced by this change.
