### PR TITLE
fix: broaden typing temporarily in `ColorTool`

### DIFF
--- a/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/FilterControls.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/FilterControls/FilterControls.tsx
@@ -32,7 +32,10 @@ const FilterControls: FunctionComponent<FilterControlProps> = ({
   const handleImage = () =>
     onChangeFilterCallback &&
     onChangeFilterCallback({ ...filter, active: !active });
-  const handleColorChange = (color: string | null) =>
+    /**
+     * to-do: remove `any` usage here
+     */
+  const handleColorChange = (color: any) =>
     color &&
     onChangeFilterCallback &&
     onChangeFilterCallback({ ...filter, color });

--- a/packages/epo-widget-lib/src/widgets/ColorTool/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/ColorTool/index.tsx
@@ -121,7 +121,11 @@ const ColorTool: FunctionComponent<ColorToolProps> = ({
     );
   };
 
-  const handleObjectSelection = (value: string | null) => {
+  /**
+   * to-do: follow the typing up the chain and remove `any` use and align
+   *        with (string | string[] | null) typing
+   */
+  const handleObjectSelection = (value: any) => {
     if (!value) return;
 
     return (

--- a/packages/epo-widget-lib/src/widgets/FilterTool/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/FilterTool/index.tsx
@@ -275,7 +275,7 @@ const FilterTool: FunctionComponent<FilterToolProps> = ({
           options={prismOptions}
           isDisabled={isDisabled}
           value={selectedColor}
-          onChangeCallback={(value?: string | null) =>
+          onChangeCallback={(value?: string | string[] |  null) =>
             selectionCallback &&
             selectionCallback((value as FilterColor) || "none")
           }


### PR DESCRIPTION
This is a temporary fix to get the build going. 

I wrote up [a ticket](https://github.com/lsst-epo/epo-react-lib/issues/388) to address the temporary `any` usage, or rather to consider a redesign of the component that led to the `string | string[] | null` prop type in the first place.