### PR TITLE
feat: add animation, rotation, and detail table visibility controls to OrbitalSimContextProvider

### DIFF
--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/OrbitalSimContext.types.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/OrbitalSimContext.types.ts
@@ -2,11 +2,17 @@ import { ReactNode } from "react";
 
 export interface OrbitalSimProviderProps {
     children: ReactNode,
-    orbitData: Orbits
+    orbitData: Orbits,
+    showDetailsTable?: boolean,
+    allowOrbitRotation?: boolean,
+    showTimeControls?: boolean
 }
 
 export type OrbitalSimContextValues = {
   orbits: Orbits;
+  showDetailsTable?: boolean;
+  allowOrbitRotation?: boolean;
+  showTimeControls?: boolean;
   setOrbits: React.Dispatch<React.SetStateAction<Orbits>>;
   observations: Observation[];
   setObservations: React.Dispatch<React.SetStateAction<Observation[]>>;

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
@@ -41,7 +41,7 @@ export function useOrbitalSimContext() {
  * 
  * @returns 
  */
-export function OrbitalSimProvider({ children, orbitData }: OrbitalSimProviderProps) {
+export function OrbitalSimProvider({ children, orbitData, showDetailsTable=false, allowOrbitRotation=false, showTimeControls=false }: OrbitalSimProviderProps) {
     const [ orbits, setOrbits] = useState<Orbits>({
         neos: null,
         activeNeo: null,
@@ -73,12 +73,18 @@ export function OrbitalSimProvider({ children, orbitData }: OrbitalSimProviderPr
 
     const values: OrbitalSimContextValues = useMemo(() => ({
         orbits,
+        showDetailsTable,
+        allowOrbitRotation,
+        showTimeControls,   
         setOrbits,
         observations,
         setObservations,
         updateActiveObservation,
   }),[
     orbits,
+    showDetailsTable,
+    allowOrbitRotation,
+    showTimeControls, 
     setOrbits,
     observations,
     setObservations,

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
@@ -12,17 +12,17 @@ import { useOrbitalSimContext } from "./Context/index.js";
 function OrbitalSim() {
   const { orbits, showDetailsTable, allowOrbitRotation, showTimeControls }= useOrbitalSimContext();
   const { 
-    paused,
     pov,
     defaultZoom,
     potentialOrbits,
+    detailsRows,
    } = orbits;
 
   const speeds = { min: 0.00001157, max: 365.25, initial: 11.574, step: 1 };
-  const [playing, setPlaying] = useState(!paused);
+  const [playing, setPlaying] = useState(showTimeControls);
   const [stepDirection, setStepDirection] = useState(1);
   const [frameOverride, setFrameOverride] = useState(0);
-  const [dayPerVizSec, setDayPerVizSec] = useState(paused ? 0 : speeds.initial);
+  const [dayPerVizSec, setDayPerVizSec] = useState(playing ? 0 : speeds.initial);
   const [elapsedTime, setElapsedTime] = useState(0);
   const [reset, setReset] = useState(0);
   const [zoomLevel, setZoomLevel] = useState(1);
@@ -74,26 +74,26 @@ function OrbitalSim() {
     <>
        <Styled.GlobalStyles/>
        <Styled.OrbitalSimWrapper>
-        {!potentialOrbits && showDetailsTable && (
+        { detailsRows && showDetailsTable && (
           <OrbitalDetails/>
         )}
-        {!paused && (
-          <PlaybackSpeed
-            {...{ elapsedTime, dayPerVizSec, speeds }}
-            sliderOnChangeCallback={handleStepSelect}
-          />
-        )}
-        {showTimeControls && (
-          <PlaybackControls
-          {...{
-            playing,
-            handleStartStop,
-            handleNext,
-            handlePrevious,
-            isDisabled,
-            handleReset
-            }}
-          />
+        {playing && (
+          <>
+            <PlaybackSpeed
+              {...{ elapsedTime, dayPerVizSec, speeds }}
+              sliderOnChangeCallback={handleStepSelect}
+            />
+            <PlaybackControls
+            {...{
+              playing,
+              handleStartStop,
+              handleNext,
+              handlePrevious,
+              isDisabled,
+              handleReset
+              }}
+            />
+          </>
         )}
        
        <Styled.CanvasWrapper orthographic={true}>

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
@@ -10,14 +10,12 @@ import * as Styled from "./styles";
 import { useOrbitalSimContext } from "./Context/index.js";
 
 function OrbitalSim() {
-  const { orbits }= useOrbitalSimContext();
+  const { orbits, showDetailsTable, allowOrbitRotation, showTimeControls }= useOrbitalSimContext();
   const { 
     paused,
     pov,
     defaultZoom,
     potentialOrbits,
-    noDetails,
-    noControls = false,
    } = orbits;
 
   const speeds = { min: 0.00001157, max: 365.25, initial: 11.574, step: 1 };
@@ -76,7 +74,7 @@ function OrbitalSim() {
     <>
        <Styled.GlobalStyles/>
        <Styled.OrbitalSimWrapper>
-        {!potentialOrbits && !noDetails && (
+        {!potentialOrbits && showDetailsTable && (
           <OrbitalDetails/>
         )}
         {!paused && (
@@ -85,7 +83,7 @@ function OrbitalSim() {
             sliderOnChangeCallback={handleStepSelect}
           />
         )}
-        {!noControls && (
+        {showTimeControls && (
           <PlaybackControls
           {...{
             playing,
@@ -99,7 +97,8 @@ function OrbitalSim() {
         )}
        
        <Styled.CanvasWrapper orthographic={true}>
-            <CameraController {...{ pov, reset }} />
+            <CameraController {...{ pov: allowOrbitRotation ? null : ( pov ?? "top"), reset }} />
+
             <Camera
               left={5000}
               right={15000}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3429,10 +3429,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@rubin-epo/epo-react-lib@^2.10.1":
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-react-lib/-/epo-react-lib-2.10.2.tgz#85dce3f579a2624b7a7dbd242294b13693f65253"
-  integrity sha512-+mDsTQwkMazJVBqrQ7Fx5h4mzniOOtss2qjQYkCqj53SQOuIADdKoFFOSh+ia9wWWkpprSVb+aZ2vR5NmQLwzg==
+"@rubin-epo/epo-react-lib@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-react-lib/-/epo-react-lib-3.0.0.tgz#aa91c247e90c09aa67affd1270f84993af616729"
+  integrity sha512-TVEy7YzTHB1LxOurSDA/QEIwa6PuHRch2e4f53cEi4qmGEOCIuPahU4T/jj11zM2ykiQ8P/ugffGyjXvy6PVmQ==
   dependencies:
     "@castiron/style-mixins" "^1.0.6"
     "@headlessui/react" "^2.2.0"


### PR DESCRIPTION
Resolves #385 

## What this change does

Updated OrbitalSimContext typing to expect three new props: `showDetailsTable`, `allowOrbitRotation`, `showTimeControls` .
Updated OrbitalSimContextProvider to accept, set defaults for, and pass along the three new props.
Updated OrbitalSim to conditionally allow camera rotation and conditionally render the details table and the animation controls based on the three new props.

## Notes for reviewers

**Allowing Orbit Rotation**
Currently, in the JSON there is a field called `pov` which should be set to a string. Rotation is locked when `pov` is set to the string values "top" or "side", with those values also determining how the camera is positioned when locked. Rotation is enabled by default otherwise (aka, when `pov` is unset/`null`). Now, we also have control over rotation from Craft as a toggle (boolean). To make these two ways of controlling the same behavior mesh, I gave the Craft toggle precedence:

1. If the toggle is enabled, and `pov` is `null` or some other string: the user can rotate the view of the orbits
2. If the toggle is enabled, and `pov` is "side" or "top": overwrite `pov` as null, and the user can rotate the view of the orbits
3. If the toggle is disabled, and `pov` is `null` or some other string: overwrite `pov` as "top", and the user cannot rotate the view
4. If the toggle is disabled, and `pov` is "side" or "top": the user cannot rotate the view

Some issues arise, especially in the third case where forcing the camera angle to the top-down orientation may not make sense based on the orbits being rendered. Some conversation with our stakeholders is needed about potentially removing the `pov` field from the JSON altogether and maybe providing the locked camera orientation via Craft. I think this can be a separate ticket, and that this works for the internal MVP.

## Testing

Some client changes were required to test these changes. See the PR for [this ticket](https://github.com/lsst-epo/investigations-client/issues/387) for more info on testing.