### PR TITLE
feat: add props and logic to OrbitalSimContext for handling selectedAnswer state

### DIFF
--- a/packages/epo-widget-lib/public/localeStrings/en/epo-widget-lib.json
+++ b/packages/epo-widget-lib/public/localeStrings/en/epo-widget-lib.json
@@ -65,7 +65,8 @@
     "selected_source": "Selected {{type}}:",
     "sources": {
       "galaxy": "Galaxy",
-      "supernova": "Supernova"
+      "supernova": "Supernova",
+      "observation": "Observation"
     }
   },
   "source_selector": {

--- a/packages/epo-widget-lib/public/localeStrings/es/epo-widget-lib.json
+++ b/packages/epo-widget-lib/public/localeStrings/es/epo-widget-lib.json
@@ -49,10 +49,11 @@
     }
   },
   "selection_list": {
-    "selected_source": "Seleccionada {{type}}:",
+    "selected_source": "{{type}} Seleccionada:",
     "sources": {
       "galaxy": "Galaxia",
-      "supernova": "Supernova"
+      "supernova": "Supernova",
+      "observation": "Observación"
     }
   },
   "source_selector": {

--- a/packages/epo-widget-lib/src/types/astro.d.ts
+++ b/packages/epo-widget-lib/src/types/astro.d.ts
@@ -1,5 +1,5 @@
 export type Band = "u" | "g" | "r" | "i" | "z" | "y";
-export type SourceType = "supernova" | "galaxy" | "galaxyFilter";
+export type SourceType = "supernova" | "galaxy" | "galaxyFilter" | "observation";
 
 export interface Source {
   id: string;

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/OrbitalSimContext.types.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/OrbitalSimContext.types.ts
@@ -5,7 +5,9 @@ export interface OrbitalSimProviderProps {
     orbitData: Orbits,
     showDetailsTable?: boolean,
     allowOrbitRotation?: boolean,
-    showTimeControls?: boolean
+    showTimeControls?: boolean,
+    selectedAnswer: string | null,
+    updateSelectedAnswer: (newSelectedAnswer: string | null) => void,
 }
 
 export type OrbitalSimContextValues = {

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
@@ -41,7 +41,7 @@ export function useOrbitalSimContext() {
  * 
  * @returns 
  */
-export function OrbitalSimProvider({ children, orbitData, showDetailsTable=false, allowOrbitRotation=false, showTimeControls=false }: OrbitalSimProviderProps) {
+export function OrbitalSimProvider({ children, orbitData, showDetailsTable=false, allowOrbitRotation=false, showTimeControls=false, selectedAnswer, updateSelectedAnswer }: OrbitalSimProviderProps) {
     const [ orbits, setOrbits] = useState<Orbits>({
         neos: null,
         activeNeo: null,
@@ -64,10 +64,20 @@ export function OrbitalSimProvider({ children, orbitData, showDetailsTable=false
         setObservations(orbitData.observations);
     }, [orbitData]);
 
+    useEffect(() => {
+        if(observations && observations.length > 0) {
+            let newObs = observations.map(e => ({ ...e, isActive: e.id === selectedAnswer }));
+            setObservations(newObs);
+        }
+    },[selectedAnswer]);
+
     const updateActiveObservation = (activeId: string) => {
         if(observations && observations.length > 0) {
             let newObs = observations.map(e => (e.id == activeId) ? {...e, isActive: true} : {...e, isActive: false});
             setObservations(newObs);
+            
+            const activeObservation = observations.find(e => (e.id === activeId));
+            updateSelectedAnswer(activeObservation?.label || null);
         }
     }
 
@@ -80,6 +90,7 @@ export function OrbitalSimProvider({ children, orbitData, showDetailsTable=false
         observations,
         setObservations,
         updateActiveObservation,
+        selectedAnswer,
   }),[
     orbits,
     showDetailsTable,
@@ -89,6 +100,7 @@ export function OrbitalSimProvider({ children, orbitData, showDetailsTable=false
     observations,
     setObservations,
     updateActiveObservation,
+    selectedAnswer,
   ]);
 
     return <OrbitalSimContext.Provider value={values}>{children}</OrbitalSimContext.Provider>

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.stories.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.stories.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import { Meta, StoryFn } from "@storybook/react";
 import { OrbitalSim }  from ".";
 import { OrbitalSimProvider } from "./Context";
+import SelectionList from "@/atomic/SelectionList";
 
 const meta: Meta<typeof OrbitalSim> = {
   component: OrbitalSim,
@@ -10,10 +12,19 @@ export default meta;
 
 // Template for all stories
 const Template: StoryFn<typeof OrbitalSim> = (args:any ) => {
-  return ( 
-    <OrbitalSimProvider orbitData={args}>
-      <OrbitalSim/>
-    </OrbitalSimProvider>
+  const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
+
+  function resetSelectedAnswer() {
+    setSelectedAnswer(null);
+  }
+
+  return (
+    <>
+      {args.observations && <SelectionList sources={ selectedAnswer ? [{ type: "observation", id: selectedAnswer}] : [] } onRemoveCallback={ resetSelectedAnswer }/>}
+      <OrbitalSimProvider orbitData={args} selectedAnswer={selectedAnswer} updateSelectedAnswer={ setSelectedAnswer }>
+        <OrbitalSim/>
+      </OrbitalSimProvider>
+    </>
   )
 };
 


### PR DESCRIPTION
## What this change does

Resolves #392 

This PR adds `selectedAnswer` and `updateSelectedAnswer` as props to the `OrbitalSimProvider` context provider to give access to higher scope shared state. Specifically shared answer state that will be passed in from the `investigations-client` implementation.

As part of the PR the SelectionList was integrated into the OrbitalSim widget in Storybook and the `SourceType` type definition was updated to include "observation" as a valid source type.

## Notes for reviewers

1. I believe the `useEffect` that I added could alternatively be implemented as shown below. It's less code, but possibly more mental overhead when someone is trying to grok what's going on.

```
useEffect(() => {
    if (observations && observations.length > 0) {
        setObservations(observations.map(e => ({ ...e, isActive: e.id === selectedAnswer })));
    }
}, [selectedAnswer]);
```

2. I wasn't sure how to add the SelectionList component to only the "Potential Orbits" version of the `OrbitalSim` widget in Storybook.

## Testing

I tested this in Storybook and in the `investigations-client`.
