### PR TITLE
Added `MovingSourceSelector` widget

### DIFF
--- a/packages/epo-widget-lib/src/atomic/Blinker/Blinker.tsx
+++ b/packages/epo-widget-lib/src/atomic/Blinker/Blinker.tsx
@@ -27,6 +27,7 @@ export interface BlinkerProps {
   className?: string;
   showControls?: boolean;
   extraControls?: ReactNode;
+  pauseCallback?: () => void;
 }
 
 const Blinker: FunctionComponent<PropsWithChildren<BlinkerProps>> = ({
@@ -42,6 +43,7 @@ const Blinker: FunctionComponent<PropsWithChildren<BlinkerProps>> = ({
   showControls = true,
   children,
   extraControls,
+  pauseCallback = () => {}
 }) => {
   const [playing, setPlaying] = useState(autoplay);
   const [loaded, setLoaded] = useState(false);
@@ -69,6 +71,7 @@ const Blinker: FunctionComponent<PropsWithChildren<BlinkerProps>> = ({
   };
 
   const handleStartStop = () => {
+    pauseCallback();
     setPlaying((value) => !value);
   };
   const handleNext = () => {

--- a/packages/epo-widget-lib/src/types/astro.d.ts
+++ b/packages/epo-widget-lib/src/types/astro.d.ts
@@ -10,6 +10,19 @@ export interface Source {
   radius?: number | string;
 }
 
+export interface MovingSource {
+  x: string;
+  y: string;
+}
+
+export interface MovingSources {
+  type: SourceType;
+  id: string;
+  color: string;
+  sources: MovingSource[];
+  radius?: number | string;
+}
+
 export interface BaseAlert {
   id: number;
   error: number;
@@ -31,10 +44,11 @@ export interface SourceDataset {
   color?: string;
   band?: Band;
   distance: number;
+  movingSources: MovingSources[] | null;
   dec: number;
   velocity: number;
   ra: number;
   redshift: number;
-  sources: Source[];
+  sources: Source[] | null;
   alerts: Alert[];
 }

--- a/packages/epo-widget-lib/src/widgets/SortableTable/SortableTable.stories.tsx
+++ b/packages/epo-widget-lib/src/widgets/SortableTable/SortableTable.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryFn } from "@storybook/react";
 
-import SortableTable from ".";
+import { SortableTable } from ".";
 
 const meta: Meta<typeof SortableTable> = {
   argTypes: {},

--- a/packages/epo-widget-lib/src/widgets/SortableTable/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/SortableTable/index.tsx
@@ -1,1 +1,1 @@
-export { default } from "./SortableTable";
+export { default as SortableTable } from "./SortableTable";

--- a/packages/epo-widget-lib/src/widgets/SourceSelector/MovingSourceMap/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/SourceSelector/MovingSourceMap/index.tsx
@@ -1,0 +1,68 @@
+import { FunctionComponent } from "react";
+import { MovingSources } from "@/types/astro";
+import { getRadius } from "../utils";
+import * as Styled from "./styles";
+
+export interface MovingSourceMapProps {
+  width: number;
+  height: number;
+  isPlaying: boolean;
+  movingSources: MovingSources[];
+  selectedSource: string[];
+  currentIndex: number;
+}
+
+const invertY = (y: number | string, height: number) => {
+  if (typeof y === "string") {
+    const isPercent = y.includes("%");
+    return isPercent ? `${100 - parseFloat(y)}%` : height - parseFloat(y);
+  }
+
+  return height - y;
+};
+
+const MovingSourceMap: FunctionComponent<MovingSourceMapProps> = ({
+  width,
+  height,
+  movingSources,
+  selectedSource,
+  currentIndex
+}) => {
+
+  return (
+    <>    {
+      movingSources && movingSources.map((movingSource, idx) => {
+        let currentFrame = movingSource.sources[currentIndex];
+        if(selectedSource.includes(movingSource.id)) {
+          return <Styled.SVG
+            preserveAspectRatio="xMidYMid meet"
+            viewBox={`0 0 ${width} ${height}`}
+          >
+            <g role="list">
+                  <Styled.Point
+                    key={`${movingSource.id}-${idx}`}
+                    cx={currentFrame.x}
+                    cy={invertY(currentFrame.y, height)}
+                    fill="transparent"
+                    stroke={movingSource.color ?? "#fed828" } 
+                    strokeWidth={3}
+                    tabIndex={0}
+                    role="listitem"
+                    r={`${getRadius(movingSource.type,NaN) * 100}%`}
+                    id={`${movingSource.id}`}
+                  />
+            </g>
+          </Styled.SVG>
+        }
+        
+      })
+    }
+    </>
+
+    
+  );
+};
+
+MovingSourceMap.displayName = "Widgets.MovingSourceMap";
+
+export default MovingSourceMap;

--- a/packages/epo-widget-lib/src/widgets/SourceSelector/MovingSourceMap/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/SourceSelector/MovingSourceMap/styles.ts
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+export const SVG = styled.svg`
+  pointer-events: none;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+`;
+
+export const Point = styled.circle`
+  cursor: pointer;
+  transition: transform ease var(--DURATION, 0.2s);
+  transform-origin: center;
+
+  &:focus {
+    outline: none;
+  }
+`;

--- a/packages/epo-widget-lib/src/widgets/SourceSelector/MovingSourceSelector.tsx
+++ b/packages/epo-widget-lib/src/widgets/SourceSelector/MovingSourceSelector.tsx
@@ -1,0 +1,228 @@
+import {
+  FunctionComponent,
+  MouseEventHandler,
+  ReactNode,
+  useState,
+} from "react";
+import { Alert, MovingSources } from "@/types/astro";
+import { useTranslation } from "react-i18next";
+import AspectRatio from "@/layout/AspectRatio";
+import Message from "./Message";
+import Loader from "@/atomic/Loader";
+import ElapsedTime from "@/atomic/ElapsedTime";
+import { Point } from "@/types/charts";
+import IconComposer from "@rubin-epo/epo-react-lib/IconComposer";
+import MovingSourceMap from "./MovingSourceMap";
+import { getRadius, toDecimalPercent } from "./utils";
+import * as Styled from "./styles";
+import useInterval from "@/hooks/useInterval";
+
+interface BlinkConfig {
+  autoplay?: boolean;
+  loop?: boolean;
+  duration?: number;
+}
+
+interface SourceSelectorProps {
+  width?: number;
+  height?: number;
+  alerts: Alert[];
+  selectedSource?: string[];
+  activeAlertIndex?: number;
+  alertChangeCallback?: (index: number) => void;
+  selectionCallback?: (data: string[]) => void;
+  blinkConfig?: BlinkConfig;
+  isDisplayOnly?: boolean;
+  isLoading?: boolean;
+  className?: string;
+  movingSources: MovingSources[];
+}
+
+const calculateDiff = (alerts: Array<Alert>, activeIndex: number) => {
+  const zeroDay = { day: 0, hour: 0 };
+  const currentAlert = alerts[activeIndex];
+
+  if (!currentAlert) return zeroDay;
+
+  const diff = currentAlert?.date - alerts[0]?.date;
+
+  if (!diff) return zeroDay;
+
+  return {
+    day: Math.round(diff) || 0,
+    hour: Math.round((24 / diff) % 24) || 0,
+  };
+};
+
+const pointInsideCircle = (click: Point, center: Point, radius: number) => {
+  return (
+    Math.pow(click.x - center.x, 2) + Math.pow(click.y - center.y, 2) <=
+    Math.pow(radius, 2)
+  );
+};
+
+const buildImageStack = (
+  alerts: Array<Alert>,
+  activeIndex: number,
+  isDisplayOnly: boolean
+) => {
+  if (isDisplayOnly) {
+    return alerts[activeIndex] ? [alerts[activeIndex].image] : [];
+  } else {
+    return alerts.map(({ image }) => image);
+  }
+};
+
+const MovingSourceSelector: FunctionComponent<SourceSelectorProps> = ({
+  width = 600,
+  height = 600,
+  selectedSource = [],
+  alerts = [],
+  activeAlertIndex = 0,
+  alertChangeCallback,
+  selectionCallback,
+  blinkConfig,
+  isDisplayOnly = false,
+  isLoading: isLoadingExternal,
+  className,
+  movingSources = []
+}) => {
+    const [ currentIndex, setCurrentIndex ] = useState<number>(0);
+    const [isLoading, setLoading] = useState(true);
+    const [isPlaying, setIsPlaying] = useState(true);
+    const [message, setMessage] = useState<ReactNode>();
+    const [isMessageVisible, setMessageVisible] = useState(false);
+    const { t } = useTranslation();
+    const isPrepared = !isLoading && !isLoadingExternal;
+
+    const clickIsInsideCircle = (
+        click: Point,
+        width: number,
+        height: number
+        ): string | undefined => {
+        if (movingSources) {
+            for(let movingSource of movingSources) {
+                const currentFrame = movingSource.sources[currentIndex];
+                let foundSource = pointInsideCircle(
+                    click,
+                    {
+                        x: toDecimalPercent(currentFrame.x) * width,
+                        y: toDecimalPercent(currentFrame.y) * height,
+                    },
+                    getRadius(movingSource.type, movingSource.radius) * width
+                )
+                if (foundSource) {
+                    return movingSource.id;
+                }
+            }
+        }
+    };
+
+    const notFound = () => {
+        setMessage(t("source_selector.messages.failure"));
+        setMessageVisible(true);
+    };
+
+    const handlePause = () => {
+        setIsPlaying(e => !e);
+    }
+    const sourceFound = () => {
+        setMessage(
+        <>
+            <IconComposer icon="checkmark" />
+            {t("source_selector.messages.success")}
+        </>
+        );
+        setMessageVisible(true);
+    };
+
+    const handleClick: MouseEventHandler<HTMLDivElement> = ({
+        clientX: x,
+        clientY: htmlY,
+        target,
+    }) => {
+        if (!isPrepared || isDisplayOnly) return;
+
+        const {
+        tagName,
+        clientWidth: width,
+        clientHeight: height,
+        } = target as HTMLElement;
+
+        if (tagName.toLowerCase() !== "img") return;
+
+        const { left, top } = (target as HTMLElement).getBoundingClientRect();
+
+        /** remember that Y for SVG starts on the top side, click value needs to be flipped */
+        const clickedId = clickIsInsideCircle(
+            { x: x - left, y: height - htmlY + top },
+            width,
+            height
+        );
+
+        if (clickedId) {
+            const isAlreadySelected = selectedSource.includes(clickedId);
+
+            if (isAlreadySelected) return;
+            selectionCallback && selectionCallback(selectedSource.concat(clickedId));
+            sourceFound();
+        } else {
+            notFound();
+        }
+    };
+
+    const handleMessageChange = () => {
+        setMessageVisible(false);
+    };
+
+    const { day, hour } = calculateDiff(alerts, activeAlertIndex);
+
+    const images = buildImageStack(alerts, activeAlertIndex, isDisplayOnly);
+
+    const nextBlink = () => {
+        if (isPlaying) {
+          if(currentIndex > movingSources[0].sources.length - 2) {
+            setCurrentIndex(0)
+          } else {
+            setCurrentIndex(e => e + 1);
+          }
+        }
+    };
+    useInterval(nextBlink, 500);
+    
+    return (
+        <AspectRatio ratio={1} {...{ className }}>
+            {!isDisplayOnly && (
+                <Message
+                onMessageChangeCallback={handleMessageChange}
+                isVisible={isMessageVisible}
+                >
+                {message}
+                </Message>
+            )}
+        {movingSources && (
+            <Styled.BackgroundBlinker
+                images={images}
+                activeIndex={currentIndex}
+                blinkCallback={alertChangeCallback}
+                loadedCallback={() => setLoading(false)}
+                onClickCallback={handleClick}
+                extraControls={
+                alerts.length > 0 &&
+                !isDisplayOnly && <ElapsedTime {...{ day, hour }} />
+                }
+                interval={400}
+                pauseCallback={handlePause}
+                {...blinkConfig}
+            >
+                <MovingSourceMap {...{ width, height, isPlaying, currentIndex, movingSources, selectedSource }} /> 
+            </Styled.BackgroundBlinker>
+         )}
+        {!isPrepared && <Loader />}
+        </AspectRatio>
+    );
+};
+
+MovingSourceSelector.displayName = "Widgets.MovingSourceSelector";
+
+export default MovingSourceSelector;

--- a/packages/epo-widget-lib/src/widgets/SourceSelector/SourceSelector.stories.tsx
+++ b/packages/epo-widget-lib/src/widgets/SourceSelector/SourceSelector.stories.tsx
@@ -1,8 +1,7 @@
 import { Meta, StoryFn } from "@storybook/react";
 import styled from "styled-components";
-import { biggerData } from "./mocks";
-
-import SourceSelector from ".";
+import { biggerData, movingData } from "./mocks";
+import SourceSelector, { MovingSourceSelector } from ".";
 import SelectionList from "@/atomic/SelectionList";
 import { useState } from "react";
 
@@ -145,7 +144,7 @@ const Template: StoryFn<typeof SourceSelector> = (args) => {
           args.alertChangeCallback && args.alertChangeCallback(index);
         }}
       />
-      {!args.isDisplayOnly && (
+      {!args.isDisplayOnly && args.sources && (
         <SelectionList
           onRemoveCallback={() => setSelectedSource([])}
           sources={args.sources.filter(({ id }) => selectedSource.includes(id))}
@@ -155,16 +154,54 @@ const Template: StoryFn<typeof SourceSelector> = (args) => {
   );
 };
 
+const MovingSourceTemplate: StoryFn<typeof MovingSourceSelector> = (args) => {
+  const [selectedSource, setSelectedSource] = useState(
+    args.selectedSource || []
+  );
+  const [activeAlertIndex, setActiveAlertIndex] = useState(
+    args.activeAlertIndex || 0
+  );
+
+  return (
+    <Container>
+        <MovingSourceSelector
+          {...args}
+          {...{ activeAlertIndex, selectedSource }}
+          selectionCallback={(sources) => {
+            setSelectedSource(sources);
+            args.selectionCallback && args.selectionCallback(sources);
+          }}
+          alertChangeCallback={(index) => {
+            setActiveAlertIndex(index);
+            args.alertChangeCallback && args.alertChangeCallback(index);
+          }}
+        />
+        {!args.isDisplayOnly && args.movingSources && (
+          <SelectionList
+            onRemoveCallback={() => setSelectedSource([])}
+            sources={args.movingSources.filter(({ id }) => selectedSource.includes(id))}
+          />
+        )}
+    </Container>
+  );
+};
+
 export const Primary: StoryFn<typeof SourceSelector> = Template.bind({});
 Primary.args = {
-  sources: biggerData.sources,
+  sources: biggerData.sources ? biggerData.sources : undefined,
   alerts: biggerData.alerts,
+};
+
+export const MovingSources: StoryFn<typeof MovingSourceSelector> = MovingSourceTemplate.bind({});
+MovingSources.args = {
+  movingSources: movingData.movingSources ? movingData.movingSources : undefined,
+  alerts: movingData.alerts,
 };
 
 export const DisplayOnly: StoryFn<typeof SourceSelector> = Template.bind({});
 DisplayOnly.args = {
-  sources: biggerData.sources,
-  selectedSource: [biggerData.sources[0].id],
+  sources: biggerData.sources ? biggerData.sources : undefined,
+  selectedSource: [biggerData.sources ? biggerData.sources[0].id : ""],
   alerts: biggerData.alerts,
   isDisplayOnly: true,
 };

--- a/packages/epo-widget-lib/src/widgets/SourceSelector/SourceSelector.test.tsx
+++ b/packages/epo-widget-lib/src/widgets/SourceSelector/SourceSelector.test.tsx
@@ -12,24 +12,28 @@ const props = { sources, alerts, selectionCallback, alertChangeCallback };
 describe("SourceSelector", () => {
   it("should select a source when its point is clicked", async () => {
     const { getByTestId, getByRole } = render(<SourceSelector {...props} />);
-    const target = sources[0];
+    const target = sources ? sources[0] : null;
     const blinker = getByTestId("blinker-container");
     const { width, height } = blinker.getBoundingClientRect();
 
-    await userEvent.pointer({
-      keys: "[MouseLeft]",
-      target: blinker,
-      coords: {
-        x: width * toDecimalPercent(target.x),
-        y: height * toDecimalPercent(target.x),
-      },
-    });
-    const points = getByRole("list");
+    if(target) {
+      await userEvent.pointer({
+        keys: "[MouseLeft]",
+        target: blinker,
+        coords: {
+          x: width * toDecimalPercent(target.x),
+          y: height * toDecimalPercent(target.x),
+        },
+      });
+    
+    
+      const points = getByRole("list");
 
-    waitFor(() => {
-      expect(selectionCallback).toBeCalledWith([target.id]);
-      expect(points.children.length).toBe(1);
-    });
+      waitFor(() => {
+        expect(selectionCallback).toBeCalledWith([target.id]);
+        expect(points.children.length).toBe(1);
+      });
+    }
   });
   it("should not make a selection when an area outside a point is clicked", async () => {
     jest.clearAllMocks();

--- a/packages/epo-widget-lib/src/widgets/SourceSelector/SourceSelector.tsx
+++ b/packages/epo-widget-lib/src/widgets/SourceSelector/SourceSelector.tsx
@@ -25,7 +25,7 @@ interface BlinkConfig {
 interface SourceSelectorProps {
   width?: number;
   height?: number;
-  sources: Source[];
+  sources?: Source[] | null;
   alerts: Alert[];
   selectedSource?: string[];
   activeAlertIndex?: number;
@@ -64,18 +64,20 @@ const clickIsInsideCircle = (
   click: Point,
   width: number,
   height: number,
-  sources: Array<Source>
+  sources: Array<Source> | null
 ): string | undefined => {
-  return sources.find(({ x, y, radius, type }) => {
-    return pointInsideCircle(
-      click,
-      {
-        x: toDecimalPercent(x) * width,
-        y: toDecimalPercent(y) * height,
-      },
-      getRadius(type, radius) * width
-    );
-  })?.id;
+  if(sources) {
+    return sources.find(({ x, y, radius, type }) => {
+      return pointInsideCircle(
+        click,
+        {
+          x: toDecimalPercent(x) * width,
+          y: toDecimalPercent(y) * height,
+        },
+        getRadius(type, radius) * width
+      );
+    })?.id;
+  }
 };
 
 const buildImageStack = (
@@ -143,12 +145,12 @@ const SourceSelector: FunctionComponent<SourceSelectorProps> = ({
     const { left, top } = (target as HTMLElement).getBoundingClientRect();
 
     /** remember that Y for SVG starts on the top side, click value needs to be flipped */
-    const clickedId = clickIsInsideCircle(
+    const clickedId = sources ? clickIsInsideCircle(
       { x: x - left, y: height - htmlY + top },
       width,
       height,
       sources
-    );
+    ) : null;
 
     if (clickedId) {
       const isAlreadySelected = selectedSource.includes(clickedId);
@@ -170,7 +172,7 @@ const SourceSelector: FunctionComponent<SourceSelectorProps> = ({
 
   const images = buildImageStack(alerts, activeAlertIndex, isDisplayOnly);
 
-  const sourcesToShow = sources.filter(({ id }) => selectedSource.includes(id));
+  const sourcesToShow = sources ? sources.filter(({ id }) => selectedSource.includes(id)) : [];
 
   return (
     <AspectRatio ratio={1} {...{ className }}>

--- a/packages/epo-widget-lib/src/widgets/SourceSelector/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/SourceSelector/index.tsx
@@ -1,4 +1,5 @@
 import SourceSelector from "./SourceSelector";
+export { default as MovingSourceSelector } from "./MovingSourceSelector";
 export { default as Message } from "./Message";
 export { default as SelectionList } from "@/atomic/SelectionList"; //! Removing this will be a breaking change in the investigations client
 export default SourceSelector;

--- a/packages/epo-widget-lib/src/widgets/SourceSelector/mocks/index.ts
+++ b/packages/epo-widget-lib/src/widgets/SourceSelector/mocks/index.ts
@@ -1,5 +1,85 @@
 import { SourceDataset } from "@/types/astro";
 
+export const movingData: SourceDataset = {
+  id: "",
+  name: "hazardous-asteroids",
+  band: "r",
+  dec: 18.74361216, // Just copied most of this data from the `biggerData` variable below
+  ra: 45.08449499,
+  distance: 141.69708547161875,
+  velocity: 9736.736057325023,
+  redshift: 0.033,
+  sources: null,
+  movingSources: [ {
+      type: "supernova",
+      id: "EDR012023i23",
+      color: "#fed828",
+      sources: [
+        {
+          x: "39%",
+          y: "37%"
+        },
+        {
+          x: "42%",
+          y: "42%",
+        },
+        {
+          x: "45%",
+          y: "45%",
+        }
+      ]
+    },
+    {
+      type: "galaxy",
+      id: "EDR97856756",
+      color:  "#fed828",
+      sources: [
+        {
+          x: "95%",
+          y: "50%",
+        },
+        {
+          x: "95%",
+          y: "50%",
+        },
+        {
+          x: "95%",
+          y: "50%",
+        }
+      ]
+    }
+  ],
+  alerts: [
+    {
+      id: 149216727,
+      error: 0.05,
+      date: 58719.46459,
+      magnitude: 17.58,
+      image: {
+        url: "https://investigations.netlify.app/images/neos/2003_QZ30_0.jpg",
+      },
+    },
+    {
+      id: 159607160,
+      error: 0.04,
+      date: 58722.4869,
+      magnitude: 17.35,
+      image: {
+        url: "	https://investigations.netlify.app/images/neos/2003_QZ30_1.jpg",
+      },
+    },
+    {
+      id: 166456030,
+      error: 0.03,
+      date: 58725.49949,
+      magnitude: 17.24,
+      image: {
+        url: "	https://investigations.netlify.app/images/neos/2003_QZ30_2.jpg",
+      },
+    }
+  ],
+};
+
 export const biggerData: SourceDataset = {
   id: "ZTF19abqmpsr",
   name: "expanding-universe::widgets.hubble_plotter.galaxies.0.name",
@@ -9,6 +89,7 @@ export const biggerData: SourceDataset = {
   distance: 141.69708547161875,
   velocity: 9736.736057325023,
   redshift: 0.033,
+  movingSources: null,
   sources: [
     {
       type: "supernova",


### PR DESCRIPTION
The use case for this sub-component is for the Hazardous Asteroids port. The existing widget only shows static sources. The new `MovingSourceSelector` widget shows sources that change change location over time with the `Blinker`. The `Blinker` widget is managed by forcing the `activeIndex` prop to match the current index for the `MovingSourceSelector`.