### PR TITLE
fix: orbital details automatically sliding out then in on widget load

### DIFF
--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/OrbitalDetails.jsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/OrbitalDetails.jsx
@@ -7,27 +7,23 @@ import { GlobalStyles } from "../styles";
 function OrbitalDetails() {
   const { orbits }= useOrbitalSimContext();
   
-    const { 
-      detailsRows: rows
-     } = orbits;
+  const { 
+    detailsRows: rows
+  } = orbits;
      
   const [active, setActive] = useState(false);
-
-  useEffect(() => {
-    if (rows) setActive(true);
-  }, [rows]);
 
   return (
     <>
       <GlobalStyles/>
       <Styled.ButtonWrapper
         styleAs="secondary"
-        isInactive={rows}
+        isInactive={!rows}
         onClick={() => { setActive(!active); console.error("click!");}}
       >
         Show Details
       </Styled.ButtonWrapper>
-        <Styled.SlideoutWrapper slideFrom="left" isOpen={!active}>
+        <Styled.SlideoutWrapper slideFrom="left" isOpen={active}>
           <Styled.SlideoutPanel>
               <h3>Orbital Details</h3>
                {


### PR DESCRIPTION
## What this change does

Resolves #373 

This PR fixes a bug where the orbital details automatically slide out and then back in on widget load by:

- Removing an unneeded useEffect (auto sliding behavior)
- Corrected flipped booleans (Details showing when they shouldn't be)

## Testing

- Reload the page with the orbital sim widget and observer the lack of an automatically sliding in and out details pane.
- Click the "Show Details" button to verify details are displayed as expected.
- Click the "Close" button to confirm the details pane closes as expected.