### PR TITLE
fix: observation property comparison in the selectedAnswer useEffect

### DIFF
--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
@@ -75,7 +75,7 @@ export function OrbitalSimProvider({
 
     useEffect(() => {
         if(observations && observations.length > 0) {
-            let newObs = observations.map(e => ({ ...e, isActive: e.id === selectedAnswer }));
+            let newObs = observations.map(e => ({ ...e, isActive: e.label === selectedAnswer }));
             setObservations(newObs);
         }
     },[selectedAnswer]);


### PR DESCRIPTION
## What this change does

Resolves #407 

This PR fixes the bug that requires the user to click an observation twice for it to show the highlighted color.

## Notes for reviewers

Include an indication of how detailed a review you want on a 1-10 scale.

Review need level 1

## Testing

Click the observation once (in your local investigations-client or storybook) and see that it shows as highlighted.