### PR TITLE
fix: orbits and object are no longer clipped by the near and far fields in the rendered view

### DIFF
--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Camera/Camera.jsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Camera/Camera.jsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useFrame, useThree } from "@react-three/fiber";
+import { OrthographicCamera } from '@react-three/drei';
 
 function Camera({ ...props }) {
   const ref = useRef();
@@ -15,7 +16,7 @@ function Camera({ ...props }) {
   useFrame(() => {
     ref.current.updateMatrixWorld();
   });
-  return <orthographicCamera ref={ref} {...props} makeDefault zoom={100}/>;
+  return <OrthographicCamera ref={ref} {...props} makeDefault/>;
 }
 
 Camera.propTypes = {

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
@@ -131,7 +131,7 @@ function OrbitalSim() {
             <CameraController {...{ pov: allowOrbitRotation ? null : ( pov ?? "top"), reset }} />
 
             <Camera
-              left={5000}
+              left={-15000}
               right={15000}
               top={15000}
               bottom={-15000}


### PR DESCRIPTION
## What this change does

Resolves #402 

By replacing the three.js primitive orthographicCamera with the helper from @react-three/drei to allow the use of the makeDefault prop, and cleaned up errors in default values.

## Notes for reviewers

This can be most easily reviewed in the repo's Storybook; however, note that this issue was preventing all of our custom set values from being applied to the camera. If you have a low number set for `defaultZoom`, you'll start zoomed way out.

I think a `defaultZoom` of `25` is good for testing.

## Testing

Rotate the rendered orbits to ensure they do not get clipped by the near or far plane.

## Screenshots (optional)

### Before:

<img width="2270" height="1226" alt="image" src="https://github.com/user-attachments/assets/a5270b6e-215d-4c6f-a12f-66d6f891326d" />


### After:

<img width="1296" height="1015" alt="image" src="https://github.com/user-attachments/assets/5beedbd1-599d-425a-b7fe-d521a6e8cbf0" />
