### PR TITLE
fix: removed unnecessary camera configs

### DIFF
--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubin-epo/epo-widget-lib",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Rubin Observatory Education & Public Outreach team React scientific and educational widgets.",
   "author": "Rubin EPO",
   "license": "MIT",

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Camera/Camera.jsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Camera/Camera.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useFrame, useThree } from "@react-three/fiber";
+import { useFrame } from "@react-three/fiber";
 import { OrthographicCamera } from '@react-three/drei';
 
 function Camera({ ...props }) {

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
@@ -129,17 +129,13 @@ function OrbitalSim() {
        
        <Styled.CanvasWrapper orthographic={true}>
             <CameraController {...{ pov: allowOrbitRotation ? null : ( pov ?? "top"), reset }} />
-
             <Camera
-              left={-2000}
-              right={2000}
-              top={1000}
-              bottom={-1000}
               near={-1000}
               far={1000}
               position={[0, 0, 10]}
               defaultZoom={defaultZoom || 3}
             />
+            
             <ambientLight intensity={0.9} />
             <Orbitals
               defaultZoom={defaultZoom || 1}


### PR DESCRIPTION
We actually don't need to define `top`/`bottom`/`left`/`right` at all in `OrbitalSim.tsx`. In fact, defining it will distort the perspective of the orthographic camera when the window is widely stretched out. Removing these attributes will let R3F handle the values automatically.