### PR TITLE
refactor: fix details table position

### DIFF
--- a/packages/epo-react-lib/src/atomic/Slideout/index.tsx
+++ b/packages/epo-react-lib/src/atomic/Slideout/index.tsx
@@ -59,22 +59,22 @@ const Slideout: FunctionComponent<PropsWithChildren<SlideoutProps>> = ({
       className={className}
       data-testid="slideout"
     >
-      {showBackground && (
-        <DialogBackdrop
-          onTransitionEnd={() => isOpen && onOpenCallback && onOpenCallback()}
-          transition
-          as={Styled.Overlay}
-          data-testid="slideoutBackdrop"
-        />
-      )}
-      <DialogPanel
-        as={Styled.Slideout}
-        style={{ "--transform": translation, ...styles }}
-        data-testid="slideoutContainer"
-        transition
-      >
-        {children}
-      </DialogPanel>
+          {showBackground && (
+            <DialogBackdrop
+              onTransitionEnd={() => isOpen && onOpenCallback && onOpenCallback()}
+              transition
+              as={Styled.Overlay}
+              data-testid="slideoutBackdrop"
+            />
+          )}
+          <DialogPanel
+            as={Styled.Slideout}
+            style={{ "--transform": translation, ...styles }}
+            data-testid="slideoutContainer"
+            transition
+          >
+            {children}
+        </DialogPanel>        
     </Dialog>
   );
 };

--- a/packages/epo-react-lib/src/atomic/SlideoutInfoCard/SlideoutInfoCard.stories.tsx
+++ b/packages/epo-react-lib/src/atomic/SlideoutInfoCard/SlideoutInfoCard.stories.tsx
@@ -38,7 +38,7 @@ const Template: StoryFn<typeof SlideoutInfoCard> = (args) => {
   const content = "Lorem ipsum dolor sit amet.";
 
   return (
-    <>
+    <div style={{height: "200px"}}>
       <Button 
         onClick={() => {isActive ? setIsActive(false) : setIsActive(true)}}
         style={{margin: "10px"}}>
@@ -50,7 +50,7 @@ const Template: StoryFn<typeof SlideoutInfoCard> = (args) => {
           <p>{content}</p>
           <p>{content}</p>
       </SlideoutInfoCard>
-    </>
+    </div>
   );
 };
 

--- a/packages/epo-react-lib/src/atomic/SlideoutInfoCard/SlideoutInfoCard.stories.tsx
+++ b/packages/epo-react-lib/src/atomic/SlideoutInfoCard/SlideoutInfoCard.stories.tsx
@@ -1,0 +1,57 @@
+import { Meta, StoryFn, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import Button from "../Button";
+
+import SlideoutInfoCard from ".";
+
+const meta: Meta<typeof SlideoutInfoCard> = {
+  component: SlideoutInfoCard,
+  argTypes: {
+    isOpen: {
+      control: "boolean",
+      description: "State that controls if the slideout is opened or not.",
+      type: "boolean",
+      table: {
+        type: {
+          summary: "boolean",
+        },
+      },
+    },
+    slideFrom: {
+      control: "select",
+      options: ["top", "bottom", "left", "right"],
+      description:
+        "Side of the window that the slideout will enter from and be pinned to",
+      table: {
+        type: {
+          summary: "top|bottom|left|right",
+        },
+      },
+    },
+  },
+};
+export default meta;
+
+const Template: StoryFn<typeof SlideoutInfoCard> = (args) => {
+
+  const [isActive, setIsActive] = useState(args.isOpen || false);
+  const content = "Lorem ipsum dolor sit amet.";
+
+  return (
+    <>
+      <Button 
+        onClick={() => {isActive ? setIsActive(false) : setIsActive(true)}}
+        style={{margin: "10px"}}>
+        {isActive ? "Hide Details" : "Show Details"}
+      </Button>
+
+      <SlideoutInfoCard isOpen={isActive} slideFrom={args.slideFrom}>
+          <p>{content}</p>
+          <p>{content}</p>
+          <p>{content}</p>
+      </SlideoutInfoCard>
+    </>
+  );
+};
+
+export const Primary: StoryObj<typeof SlideoutInfoCard> = Template.bind({});

--- a/packages/epo-react-lib/src/atomic/SlideoutInfoCard/SlideoutInfoCard.tsx
+++ b/packages/epo-react-lib/src/atomic/SlideoutInfoCard/SlideoutInfoCard.tsx
@@ -1,0 +1,26 @@
+import {FunctionComponent, ReactNode} from 'react';
+import * as Styled from "./styles";
+
+type SlideFrom = "top" | "right" | "bottom" | "left";
+
+interface SlideoutInfoCardProps {
+  isOpen?: boolean;
+  slideFrom?: SlideFrom;
+  className?: string;
+  children: ReactNode,
+};
+
+const SlideoutInfoCard: FunctionComponent<SlideoutInfoCardProps> = ({
+  isOpen = false, 
+  slideFrom = "left", 
+  children,
+}) => {
+
+  return (
+    <Styled.SlideoutInfoCard isOpen={isOpen} slideFrom={slideFrom}>
+      {children}
+    </Styled.SlideoutInfoCard>
+  );
+}
+
+export default SlideoutInfoCard;

--- a/packages/epo-react-lib/src/atomic/SlideoutInfoCard/index.tsx
+++ b/packages/epo-react-lib/src/atomic/SlideoutInfoCard/index.tsx
@@ -1,25 +1,2 @@
-import {ReactNode} from 'react';
-import * as Styled from "./styles";
+export {default} from "./SlideoutInfoCard";
 
-type SlideFrom = "top" | "right" | "bottom" | "left";
-interface SlideoutInfoCardProps {
-  isOpen?: boolean;
-  slideFrom?: SlideFrom;
-  className?: string;
-  children: ReactNode,
-};
-
-function SlideoutInfoCard({
-  isOpen = false, 
-  slideFrom = "left", 
-  children
-} : SlideoutInfoCardProps) {
-
-  return (
-    <Styled.SlideoutInfoCard isOpen={isOpen} slideFrom={slideFrom}>
-      {children}
-    </Styled.SlideoutInfoCard>
-  );
-}
-
-export default SlideoutInfoCard;

--- a/packages/epo-react-lib/src/atomic/SlideoutInfoCard/index.tsx
+++ b/packages/epo-react-lib/src/atomic/SlideoutInfoCard/index.tsx
@@ -1,0 +1,25 @@
+import {ReactNode} from 'react';
+import * as Styled from "./styles";
+
+type SlideFrom = "top" | "right" | "bottom" | "left";
+interface SlideoutInfoCardProps {
+  isOpen?: boolean;
+  slideFrom?: SlideFrom;
+  className?: string;
+  children: ReactNode,
+};
+
+function SlideoutInfoCard({
+  isOpen = false, 
+  slideFrom = "left", 
+  children
+} : SlideoutInfoCardProps) {
+
+  return (
+    <Styled.SlideoutInfoCard isOpen={isOpen} slideFrom={slideFrom}>
+      {children}
+    </Styled.SlideoutInfoCard>
+  );
+}
+
+export default SlideoutInfoCard;

--- a/packages/epo-react-lib/src/atomic/SlideoutInfoCard/styles.ts
+++ b/packages/epo-react-lib/src/atomic/SlideoutInfoCard/styles.ts
@@ -12,7 +12,10 @@ type Direction = keyof typeof directions;
 export const SlideoutInfoCard = styled.div<{isOpen?: boolean; slideFrom?: Direction;}>`
   position: absolute;
 
-  transition: transform 0.5s ease-in-out;
+  transition: transform 0.5s ease-in-out,
+              opacity 0s linear ${({isOpen})=> isOpen ? "0s" : "0.5s"},
+              z-index 0s linear ${({isOpen})=> isOpen ? "0s" : "0.5s"};
+  
   transform: ${(
     {isOpen, slideFrom}) => 
       isOpen ? 'translate(0, 0)' : 

--- a/packages/epo-react-lib/src/atomic/SlideoutInfoCard/styles.ts
+++ b/packages/epo-react-lib/src/atomic/SlideoutInfoCard/styles.ts
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+
+const directions = {
+  right: 'translateX(100%)',
+  left: 'translateX(-100%)',
+  top: 'translateY(-100%)',
+  bottom: 'translateY(100%)',
+}
+
+type Direction = keyof typeof directions;
+
+export const SlideoutInfoCard = styled.div<{isOpen?: boolean; slideFrom?: Direction;}>`
+  position: absolute;
+
+  transition: transform 0.5s ease-in-out;
+  transform: ${(
+    {isOpen, slideFrom}) => 
+      isOpen ? 'translate(0, 0)' : 
+      slideFrom ? directions[slideFrom] : directions["left"]};
+  
+  opacity: ${props => (props.isOpen ? 1 : 0)};
+  z-index: ${props => (props.isOpen ? 100 : -1)};
+`;

--- a/packages/epo-react-lib/src/index.ts
+++ b/packages/epo-react-lib/src/index.ts
@@ -28,6 +28,7 @@ export { default as Toast } from "@/atomic/Toast";
 export { default as Video } from "@/atomic/Video";
 export { default as Stack } from "@/atomic/Stack";
 export { default as HorizontalSlider } from "@/molecules/HorizontalSlider";
+export {default as SlideoutInfoCard} from "@/atomic/SlideoutInfoCard";
 
 // Content Blocks
 export { default as SimpleTable } from "@/content-blocks/SimpleTable";

--- a/packages/epo-react-lib/src/index.ts
+++ b/packages/epo-react-lib/src/index.ts
@@ -28,7 +28,7 @@ export { default as Toast } from "@/atomic/Toast";
 export { default as Video } from "@/atomic/Video";
 export { default as Stack } from "@/atomic/Stack";
 export { default as HorizontalSlider } from "@/molecules/HorizontalSlider";
-export {default as SlideoutInfoCard} from "@/atomic/SlideoutInfoCard";
+export { default as SlideoutInfoCard} from "@/atomic/SlideoutInfoCard";
 
 // Content Blocks
 export { default as SimpleTable } from "@/content-blocks/SimpleTable";

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import OrbitalDetails from "./Orbitals/OrbitalDetails.jsx";
 import CameraController from "./Camera/CameraController.jsx";
 import Camera from "./Camera/Camera.jsx";
@@ -83,7 +83,6 @@ function OrbitalSim() {
   } 
 
   let isDisabled = false;
-
   return (
     <>
        <Styled.GlobalStyles/>
@@ -104,7 +103,7 @@ function OrbitalSim() {
         ) : (
           <>
         { detailsRows && showDetailsTable && (
-          <OrbitalDetails/>
+          <OrbitalDetails />
         )}
         {showTimeControls && (
           <>

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
@@ -85,23 +85,22 @@ function OrbitalSim() {
   let isDisabled = false;
   return (
     <>
-       <Styled.GlobalStyles/>
-       <Styled.OrbitalSimWrapper>
-        {swappableOrbits ? (
-          <Styled.SwappableOrbitsContainer>
-            {orbits && orbits.neos && orbits.neos.map((neo: Neo) => (
-              <Styled.SwappableOrbitButton 
-                onClick={() => updateSwappableOrbit(neo)} 
-                data-active={
-                  ((Object.keys(currentSwappableOrbit).length) ? (neo.Principal_desig === currentSwappableOrbit.neos[0].Principal_desig) : false)
-                }>
-                  {neo.Ref}
-              </Styled.SwappableOrbitButton>
-            ))}
-          </Styled.SwappableOrbitsContainer>
-          
-        ) : (
-          <>
+      <Styled.GlobalStyles/>
+      <Styled.OrbitalSimWrapper>
+      {swappableOrbits ? (
+        <Styled.SwappableOrbitsContainer>
+          {orbits && orbits.neos && orbits.neos.map((neo: Neo) => (
+            <Styled.SwappableOrbitButton 
+              onClick={() => updateSwappableOrbit(neo)} 
+              data-active={
+                ((Object.keys(currentSwappableOrbit).length) ? (neo.Principal_desig === currentSwappableOrbit.neos[0].Principal_desig) : false)
+              }>
+                {neo.Ref}
+            </Styled.SwappableOrbitButton>
+          ))}
+        </Styled.SwappableOrbitsContainer>
+      ) : (
+        <>
         { detailsRows && showDetailsTable && (
           <OrbitalDetails />
         )}
@@ -126,7 +125,7 @@ function OrbitalSim() {
         </>
       )}
        
-       <Styled.CanvasWrapper orthographic={true}>
+      <Styled.CanvasWrapper orthographic={true}>
             <CameraController {...{ pov: allowOrbitRotation ? null : ( pov ?? "top"), reset }} />
             <Camera
               near={-1000}

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/OrbitalDetails.jsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/OrbitalDetails.jsx
@@ -5,6 +5,7 @@ import * as Styled from "./styles";
 import { GlobalStyles } from "../styles";
 
 function OrbitalDetails() {
+
   const { orbits }= useOrbitalSimContext();
   
   const { 
@@ -19,33 +20,33 @@ function OrbitalDetails() {
       <Styled.ButtonWrapper
         styleAs="secondary"
         isInactive={!rows}
-        onClick={() => { setActive(!active); console.error("click!");}}
+        onClick={() => { setActive(!active);}}
       >
-        Show Details
+        {active ? "Hide Details" : "Show Details"}
       </Styled.ButtonWrapper>
-        <Styled.SlideoutWrapper slideFrom="left" isOpen={active}>
-          <Styled.SlideoutPanel>
-              <h3>Orbital Details</h3>
-               {
-                rows && rows.map(e => (
-                  <Styled.SlideoutRow>
-                    <Styled.SlideoutColLeft>
-                      <p>{e.rowTitle}</p>
-                    </Styled.SlideoutColLeft>
-                    <Styled.SlideoutColRight>
-                      <p>{e.rowContent}</p>
-                    </Styled.SlideoutColRight>
-                  </Styled.SlideoutRow >
-                ))
-               }
-            <Button
-              isBlock
-              onClick={() => setActive(!active)}
-            >
-              Close
-            </Button>
-          </Styled.SlideoutPanel>
-        </Styled.SlideoutWrapper>
+      <Styled.SlideoutWrapper slideFrom="left" isOpen={active} >
+        <Styled.SlideoutPanel>
+            <h3>Orbital Details</h3>
+              {
+              rows && rows.map(e => (
+                <Styled.SlideoutRow>
+                  <Styled.SlideoutColLeft>
+                    <p>{e.rowTitle}</p>
+                  </Styled.SlideoutColLeft>
+                  <Styled.SlideoutColRight>
+                    <p>{e.rowContent}</p>
+                  </Styled.SlideoutColRight>
+                </Styled.SlideoutRow >
+              ))
+              }
+          <Button
+            isBlock
+            onClick={() => setActive(!active)}
+          >
+            Close
+          </Button>
+        </Styled.SlideoutPanel>
+      </Styled.SlideoutWrapper>
     </>
   );
 }

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/OrbitalDetails.jsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/OrbitalDetails.jsx
@@ -26,25 +26,27 @@ function OrbitalDetails() {
       </Styled.ButtonWrapper>
       <Styled.SlideoutWrapper slideFrom="left" isOpen={active} >
         <Styled.SlideoutPanel>
-            <h3>Orbital Details</h3>
-              {
-              rows && rows.map(e => (
-                <Styled.SlideoutRow>
-                  <Styled.SlideoutColLeft>
-                    <p>{e.rowTitle}</p>
-                  </Styled.SlideoutColLeft>
-                  <Styled.SlideoutColRight>
-                    <p>{e.rowContent}</p>
-                  </Styled.SlideoutColRight>
-                </Styled.SlideoutRow >
-              ))
-              }
+
+          <h3>Orbital Details</h3>
+
+          {rows && rows.map(e => (
+            <Styled.SlideoutRow>
+              <Styled.SlideoutColLeft>
+                <p>{e.rowTitle}</p>
+              </Styled.SlideoutColLeft>
+              <Styled.SlideoutColRight>
+                <p>{e.rowContent}</p>
+              </Styled.SlideoutColRight>
+            </Styled.SlideoutRow >
+          ))}
+
           <Button
             isBlock
             onClick={() => setActive(!active)}
           >
             Close
           </Button>
+          
         </Styled.SlideoutPanel>
       </Styled.SlideoutWrapper>
     </>

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/styles.ts
@@ -1,12 +1,14 @@
 "use clients";
 import styled from "styled-components";
 import Button from "@rubin-epo/epo-react-lib/Button";
-import Slideout from "@rubin-epo/epo-react-lib/Slideout";
+import SlideoutInfoCard from "@rubin-epo/epo-react-lib/SlideoutInfoCard";
 
-export const SlideoutWrapper = styled(Slideout)`
-    & > div:first-of-type {
-      display: none;
-    }
+export const SlideoutWrapper = styled(SlideoutInfoCard)`
+  position: absolute;
+
+  & > div:first-of-type {
+    display: none;
+  }
 `;
 
 export const Label = styled.div`

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/styles.ts
@@ -58,6 +58,7 @@ export const SlideoutRow = styled.div`
   display: flex;
   gap: 10px;
   margin: 0px;
+  color: var(--black);
 `;
 
 export const SlideoutColLeft = styled.div`

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/styles.ts
@@ -40,6 +40,7 @@ export const GlobalStyles = createGlobalStyle`
 
 export const OrbitalSimWrapper = styled.div`
     position: relative;
+    overflow: hidden;
     height: var(--tallestSquareWidget);
     min-height: 500px;
     background-color: #000000;


### PR DESCRIPTION
Resolves #395 
Resolves #415 

## What this change does
 
Creates a new generic slide-out component, `SlideoutInfoCard` for the `OrbitalDetails` component in the `OrbitalSim` widget. `SlideoutInfoCard` builds off of a `div` instead of a Headless UI `Dialog` like the original `Slideout` component. This allows `OrbitalDetails` to render within the `OrbitalSim` instead of out at the browser window level, which is how the `Dialog` component was designed.

## Things of Note 
The original `Slideout` mixed JS and CSS directly in the component to handle the dynamic translations. It worked well with the `transition` prop provided on the `Dialog` component. To handle the translation directions with a plain `div`, I’m passing dynamic props into the styled component for `SlideoutInfoCard`. As a result, `SlideoutInfoCard`'s `style.ts` looks like it's halfway to JS, but it felt like the cleanest way to mirror the existing Headless UI transition logic while keeping styles externalized. 

I did try to keep the dynamic logic in the component itself, but I was ending up with some long inline styles on my `div`. Since we aren’t using CSS Modules yet, this felt like the best middle ground where I'm leveraging some features of Styled Components while we're still stuck with it. I’m definitely open to feedback here (especially if you have ideas on how to structure this to make the likely future migration to CSS Modules easier).

## Testing

Use Storybook to test in isolation. I configured the slide direction to react to the dropdown in the Storybook console, but changing the `isActive` boolean in the Storybook console won't do anything. The slideout's visibility only responds to the button click.

To test locally, add the OrbitalSim to a page in a local instance of the Investigations Craft API and spin up the client. Ensure the "Show Details" toggle is enabled and that the JSON data for the widget defines content for the table rows.

### Before:
<img width="1652" height="915" alt="image" src="https://github.com/user-attachments/assets/f4d52f0c-ac7c-43de-8019-e1f96c946fe1" />

### After:
<img width="1272" height="877" alt="image" src="https://github.com/user-attachments/assets/94c91e80-fa10-4018-98eb-0c79c7b191f8" />
