### PR TITLE
fix: add missing useEffect dependency which prevents proper rendering in the investigations-client

### DIFF
--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
@@ -78,7 +78,7 @@ export function OrbitalSimProvider({
             let newObs = observations.map(e => ({ ...e, isActive: e.label === selectedAnswer }));
             setObservations(newObs);
         }
-    },[selectedAnswer]);
+    },[selectedAnswer, observations]);
 
     const updateActiveObservation = (activeId: string) => {
         if(observations && observations.length > 0) {


### PR DESCRIPTION
## What this change does

resolves #416 

This fix is related to resolving the [`investigations-client` 406 ticket](https://github.com/lsst-epo/investigations-client/issues/406)

## Notes for reviewers

This fix won't be apparent until the PR associated with the ticket mentioned above is merged as it's effects aren't apparent until it is included in the client codebase's initial rendering loop.
