### PR TITLE
Ji 418 fix use effect infinite re render in orbital sim context

### DIFF
--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rubin-epo/epo-widget-lib",
-  "version": "2.0.7",
+  "version": "2.0.9",
   "description": "Rubin Observatory Education & Public Outreach team React scientific and educational widgets.",
   "author": "Rubin EPO",
   "license": "MIT",
@@ -102,7 +102,7 @@
   "dependencies": {
     "@react-three/drei": "^10.7.6",
     "@react-three/fiber": "9",
-    "@rubin-epo/epo-react-lib": "3.0.0",
+    "@rubin-epo/epo-react-lib": "^3.0.1",
     "@rubin-epo/epo-widget-lib": "2.0.2",
     "context-filter-polyfill": "^0.3.6",
     "d3-array": "^3.2.4",

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/OrbitalSimContext.types.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/OrbitalSimContext.types.ts
@@ -18,9 +18,9 @@ export type OrbitalSimContextValues = {
   showTimeControls?: boolean;
   setOrbits: React.Dispatch<React.SetStateAction<Orbits>>;
   observations: Observation[];
-  setObservations: React.Dispatch<React.SetStateAction<Observation[]>>;
   updateActiveObservation: (activeId: string) => void;
-  swappableOrbits: boolean
+  selectedAnswer: string | null;
+  swappableOrbits: boolean;
 };
 
 export type Observation = {

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
@@ -73,12 +73,15 @@ export function OrbitalSimProvider({
         setObservations(orbitData.observations);
     }, [orbitData]);
 
-    useEffect(() => {
+    const observationsWithActiveSelection = useMemo(() => {
         if(observations && observations.length > 0) {
-            let newObs = observations.map(e => ({ ...e, isActive: e.label === selectedAnswer }));
-            setObservations(newObs);
+            return observations.map(e => ({ ...e, isActive: e.label === selectedAnswer }));
+        } else {
+            return [];
         }
-    },[selectedAnswer, observations]);
+    },
+        [selectedAnswer, observations]
+    );
 
     const updateActiveObservation = (activeId: string) => {
         if(observations && observations.length > 0) {
@@ -96,8 +99,7 @@ export function OrbitalSimProvider({
         allowOrbitRotation,
         showTimeControls,   
         setOrbits,
-        observations,
-        setObservations,
+        observations: observationsWithActiveSelection,
         updateActiveObservation,
         selectedAnswer,
         swappableOrbits
@@ -107,8 +109,7 @@ export function OrbitalSimProvider({
     allowOrbitRotation,
     showTimeControls, 
     setOrbits,
-    observations,
-    setObservations,
+    observationsWithActiveSelection,
     updateActiveObservation,
     selectedAnswer,
     swappableOrbits

--- a/yarn.lock
+++ b/yarn.lock
@@ -3446,6 +3446,42 @@
     styled-components "^6.1.16"
     utopia-core "^1.6.0"
 
+"@rubin-epo/epo-react-lib@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-react-lib/-/epo-react-lib-3.0.1.tgz#84ef0eb31b7c86c39efc66dd7c6279a7493ab0f2"
+  integrity sha512-/hJ6CwjMLY9LUWS0Mfp5cBXsV4LrF7gaYOHMAesrXxnMJvQUHwKLcFuT0InRxJFCtoqYESBUD/54Vrdceq4QlQ==
+  dependencies:
+    "@castiron/style-mixins" "^1.0.6"
+    "@headlessui/react" "^2.2.0"
+    flickity "^3.0.0"
+    focus-trap "^7.4.2"
+    lodash "^4.17.21"
+    react-icons "^5.5.0"
+    react-player "^2.14.1"
+    react-share "^5.2.2"
+    react-slider "^2.0.6"
+    styled-components "^6.1.16"
+    utopia-core "^1.6.0"
+
+"@rubin-epo/epo-widget-lib@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-widget-lib/-/epo-widget-lib-2.0.2.tgz#1cab03185f30f6524482a6fc769c464876cde50c"
+  integrity sha512-BqdsNDO26OpRXU1f3A4/FWZin7CGxDwntHxa5jtHeutF/JcYtA2zywWePapjBT2H94WiBAVFaqheXcglW05t1g==
+  dependencies:
+    "@react-three/drei" "^10.7.6"
+    "@react-three/fiber" "9"
+    "@rubin-epo/epo-react-lib" "3.0.0"
+    context-filter-polyfill "^0.3.6"
+    d3-array "^3.2.4"
+    d3-geo "^3.1.1"
+    d3-geo-projection "^4.0.0"
+    lodash "^4.17.21"
+    react-slider "^2.0.6"
+    skia-canvas "^1.0.2"
+    styled-components "^6.1.16"
+    three "^0.181.0"
+    use-resize-observer "^9.1.0"
+
 "@rushstack/eslint-patch@^1.10.3":
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz#4f97581e114fc79f246cee3723a5c4edd3b62415"
@@ -5989,7 +6025,14 @@ conventional-changelog-angular@^8.0.0:
   dependencies:
     compare-func "^2.0.0"
 
-conventional-changelog-conventionalcommits@8.0.0, conventional-changelog-conventionalcommits@^7.0.2, conventional-changelog-conventionalcommits@^8.0.0:
+conventional-changelog-conventionalcommits@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz#aa5da0f1b2543094889e8cf7616ebe1a8f5c70d5"
+  integrity sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==
+  dependencies:
+    compare-func "^2.0.0"
+
+conventional-changelog-conventionalcommits@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz#3fa2857c878701e7f0329db5a1257cb218f166fe"
   integrity sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==


### PR DESCRIPTION
## What this change does

Resolves #418

This PR replaces the `selectedAnswer` /`observations` useEffect with a memoized array (useMemo) to prevent infinite re-renders. 

The observations array initial setting was triggering the useEffect which was updating the observations array which triggered the useEffect and so on...

It also removes the `setObservations` function exposed in the context's values as that could allow a consumer of the library to bypass the memoized mutation.

## Notes for reviewers

The `epo-react-lib` dependency version in the `epo-widget-lib` package was bumped to `v3.0.1` as part of this PR.

## Testing

Each version of the `OrbitalSim` widget in the Storybook was reviewed to make sure all intended functionality was intact (and that the Storybook pages would load).

I used `yarn link` to test this fix in my local `investigations-client` and confirmed that the `OrbitalSim` widgets that I've been testing with behaved correctly and I was able to navigate past their pages.