### PR TITLE
feat: styling refinement for SortableTable

### DIFF
--- a/packages/epo-react-lib/src/atomic/SlideoutInfoCard/SlideoutInfoCard.tsx
+++ b/packages/epo-react-lib/src/atomic/SlideoutInfoCard/SlideoutInfoCard.tsx
@@ -1,9 +1,9 @@
 import {FunctionComponent, ReactNode} from 'react';
 import * as Styled from "./styles";
 
-type SlideFrom = "top" | "right" | "bottom" | "left";
+export type SlideFrom = "top" | "right" | "bottom" | "left";
 
-interface SlideoutInfoCardProps {
+export interface SlideoutInfoCardProps {
   isOpen?: boolean;
   slideFrom?: SlideFrom;
   className?: string;

--- a/packages/epo-react-lib/src/atomic/SortButton/SortButton.stories.tsx
+++ b/packages/epo-react-lib/src/atomic/SortButton/SortButton.stories.tsx
@@ -1,0 +1,11 @@
+import SortButton from ".";
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta<typeof SortButton> = {
+  component: SortButton,
+};
+
+export default meta;
+
+export const Primary: StoryObj<typeof SortButton> = {}
+

--- a/packages/epo-react-lib/src/atomic/SortButton/index.tsx
+++ b/packages/epo-react-lib/src/atomic/SortButton/index.tsx
@@ -1,0 +1,21 @@
+import { FunctionComponent } from "react";
+import IconComposer from "@/svg/IconComposer";
+import * as Styled from "./styles";
+
+export type SortDirection = "asc" | "desc" | "none";
+
+export interface SortButtonProps {
+  sortDirection?: SortDirection
+}
+
+const SortButton : FunctionComponent<SortButtonProps> = ({sortDirection}) => { 
+  return (
+    <Styled.SortButton sortDirection={sortDirection}>
+      <IconComposer icon="CaretUp" className="top-caret"/>
+      <IconComposer icon="CaretDown" className="bottom-caret" />
+    </Styled.SortButton>
+    
+  );
+};
+
+export default SortButton;

--- a/packages/epo-react-lib/src/atomic/SortButton/styles.ts
+++ b/packages/epo-react-lib/src/atomic/SortButton/styles.ts
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+import { SortDirection } from ".";
+
+
+export const SortButton = styled.div<{ sortDirection?: SortDirection }>`
+  display: inline-flex;
+  flex-direction: column;
+  
+  padding: 4px 2px;
+
+  & > * {
+    padding: 2px;
+  }
+
+  .top-caret {
+    fill: ${({sortDirection}) => sortDirection === "asc" ? "var(--color-rubin-gray-300)" : "var(--color-rubin-gray-100)"};
+  }
+
+  .bottom-caret {
+    fill: ${({sortDirection}) => sortDirection === "desc" ? "var(--color-rubin-gray-300)" : "var(--color-rubin-gray-100)"};
+  }
+`;

--- a/packages/epo-react-lib/src/atomic/SortButton/styles.ts
+++ b/packages/epo-react-lib/src/atomic/SortButton/styles.ts
@@ -13,10 +13,10 @@ export const SortButton = styled.div<{ sortDirection?: SortDirection }>`
   }
 
   .top-caret {
-    fill: ${({sortDirection}) => sortDirection === "asc" ? "var(--color-rubin-gray-300)" : "var(--color-rubin-gray-100)"};
+    fill: ${({sortDirection}) => sortDirection === "asc" ? "var(--color-rubin-gray-300)" : "#ffffff"};
   }
 
   .bottom-caret {
-    fill: ${({sortDirection}) => sortDirection === "desc" ? "var(--color-rubin-gray-300)" : "var(--color-rubin-gray-100)"};
+    fill: ${({sortDirection}) => sortDirection === "desc" ? "var(--color-rubin-gray-300)" : "#ffffff"};
   }
 `;

--- a/packages/epo-react-lib/src/svg/icons/CaretUp.tsx
+++ b/packages/epo-react-lib/src/svg/icons/CaretUp.tsx
@@ -26,6 +26,6 @@ const CaretUp: FunctionComponent<SVGProps> = ({
   );
 };
 
-CaretUp.displayName = "SVG.CaretDown";
+CaretUp.displayName = "SVG.CaretUp";
 
 export default CaretUp;

--- a/packages/epo-react-lib/src/svg/icons/CaretUp.tsx
+++ b/packages/epo-react-lib/src/svg/icons/CaretUp.tsx
@@ -1,0 +1,31 @@
+import { FunctionComponent } from "react";
+import { stripUnit } from "@castiron/style-mixins";
+import { SVGProps } from "@/types/svg";
+import defaultProps from "./defaultProps";
+
+const CaretUp: FunctionComponent<SVGProps> = ({
+  className,
+  size = 18,
+  fill = "currentColor",
+}) => {
+  const uniqueProps = {
+    viewBox: "0 0 18 9",
+    width: size,
+    height: stripUnit(size) / 2,
+    fill,
+    className,
+  };
+
+  return (
+    <svg {...{ ...defaultProps, ...uniqueProps }} style={{ 
+        transform: 'scaleY(-1)', 
+        transformOrigin: 'center' 
+      }}>
+      <path d="M0,0,9,9l9-9Z" />
+    </svg>
+  );
+};
+
+CaretUp.displayName = "SVG.CaretDown";
+
+export default CaretUp;

--- a/packages/epo-react-lib/src/svg/icons/index.ts
+++ b/packages/epo-react-lib/src/svg/icons/index.ts
@@ -5,6 +5,7 @@ import BackwardStep from "./BackwardStep";
 import Calendar from "./Calendar";
 import Cancel from "./Cancel";
 import CaretDown from "./CaretDown";
+import CaretUp from "./CaretUp";
 import CheckeredFlag from "./CheckeredFlag";
 import Checkmark from "./Checkmark";
 import CheckmarkCircle from "./CheckmarkCircle";
@@ -77,6 +78,7 @@ const Icons = {
   Calendar,
   Cancel,
   CaretDown,
+  CaretUp,
   CheckeredFlag,
   Checkmark,
   CheckmarkCircle,

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/OrbitalDetails.jsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/OrbitalDetails.jsx
@@ -30,7 +30,7 @@ function OrbitalDetails() {
           <h3>Orbital Details</h3>
 
           {rows && rows.map(e => (
-            <Styled.SlideoutRow>
+            <Styled.SlideoutRow key={e.rowTitle}>
               <Styled.SlideoutColLeft>
                 <p>{e.rowTitle}</p>
               </Styled.SlideoutColLeft>

--- a/packages/epo-widget-lib/src/widgets/SortableTable/SortableTable.tsx
+++ b/packages/epo-widget-lib/src/widgets/SortableTable/SortableTable.tsx
@@ -66,8 +66,11 @@ const SortableTable = <T extends Record<string, string | number | null>>({
   }, [rows, sortKey, sortDirection]);
 
   function getSortArrow(key: string) {
-    if (sortKey !== key) return <SortButton sortDirection={NONE}/>;
-    return sortDirection === ASC ? <SortButton sortDirection={ASC}/> : <SortButton sortDirection={DESC}/>;
+    if (sortKey !== key) {
+      return <SortButton sortDirection={NONE}/>;
+    }
+
+    return <SortButton sortDirection={sortDirection === ASC ? ASC : DESC}/>
   }
 
   return (

--- a/packages/epo-widget-lib/src/widgets/SortableTable/SortableTable.tsx
+++ b/packages/epo-widget-lib/src/widgets/SortableTable/SortableTable.tsx
@@ -1,106 +1,116 @@
 import { useMemo, useState } from "react";
+import SortButton from "@rubin-epo/epo-react-lib/SortButton";
 import * as Styled from "./styles";
 
 type TableDataProps<T extends Record<string, string | number | null>> = {
-    tableData: T[]
-}
+  tableData: T[];
+};
 
 const ASC = "asc";
 const DESC = "desc";
+const NONE = "none";
 type SortKey = string;
-type SortDirection = "asc" | "desc";
+type SortDirection = "asc" | "desc" | "none";
 
 /**
  * This widget will take an array of uniform (same properties across all elements)
  * objects and render a table from the values. The table headers will be created
  * based on the property names. The table can be sorted ascending or descending
  * by one column at a time. If non-uniform objects are contained in the array,
- * the widget will only build out the columns specific by the properties on the 
+ * the widget will only build out the columns specific by the properties on the
  * first element of the array.
- * 
- * @param tabledata: an array of objects that will be used to build the table 
+ *
+ * @param tabledata: an array of objects that will be used to build the table
  * @returns the sortable table
  */
 const SortableTable = <T extends Record<string, string | number | null>>({
-    tableData
+  tableData,
 }: TableDataProps<T>) => {
-    const [rows] = useState<T[]>(tableData);
-    const columns = tableData ? Object.keys(rows[0]) as string[] : null;
-    const [sortKey, setSortKey] = useState<SortKey>(columns ? columns[0] : "");
-    const [sortDirection, setSortDirection] = useState<SortDirection>(ASC);
+  const [rows] = useState<T[]>(tableData);
+  const columns = tableData ? (Object.keys(rows[0]) as string[]) : null;
+  const [sortKey, setSortKey] = useState<SortKey>(columns ? columns[0] : "");
+  const [sortDirection, setSortDirection] = useState<SortDirection>(ASC);
 
-    function handleSort(key: string) {
-        if (sortKey === key) {
-            setSortDirection((prev) => (prev === ASC ? DESC : ASC));
-            return;
-        }
-
-        setSortKey(key);
-        setSortDirection(ASC);
+  function handleSort(key: string) {
+    if (sortKey === key) {
+      setSortDirection((prev) => (prev === ASC ? DESC : ASC));
+      return;
     }
 
-    const sortedRows = useMemo(() => {
-        if(rows) {
-            const sorted = [...rows].sort((a, b) => {
-                const firstNum = a[sortKey];
-                const secondNum = b[sortKey];
+    setSortKey(key);
+    setSortDirection(ASC);
+  }
 
-                if (typeof firstNum === "number" && typeof secondNum === "number") {
-                    return sortDirection === ASC ? firstNum - secondNum : secondNum - firstNum;
-                }
+  const sortedRows = useMemo(() => {
+    if (rows) {
+      const sorted = [...rows].sort((a, b) => {
+        const firstNum = a[sortKey];
+        const secondNum = b[sortKey];
 
-                const aSort = String(firstNum).toLowerCase();
-                const bSort = String(secondNum).toLowerCase();
-
-                return sortDirection === ASC
-                        ? aSort.localeCompare(bSort)
-                        : bSort.localeCompare(aSort);
-            });
-
-        return sorted;
+        if (typeof firstNum === "number" && typeof secondNum === "number") {
+          return sortDirection === ASC
+            ? firstNum - secondNum
+            : secondNum - firstNum;
         }
-    }, [rows, sortKey, sortDirection]);
 
-    function getSortArrow(key: string) {
-        if (sortKey !== key) return "";
-        return sortDirection === ASC ? "↑" : "↓";
+        const aSort = String(firstNum).toLowerCase();
+        const bSort = String(secondNum).toLowerCase();
+
+        return sortDirection === ASC
+          ? aSort.localeCompare(bSort)
+          : bSort.localeCompare(aSort);
+      });
+
+      return sorted;
     }
+  }, [rows, sortKey, sortDirection]);
 
-    return (
-        <>
-            {tableData && 
-            <Styled.Table>
-                <thead>
-                    <tr>
-                        {columns && columns.map((key) => (
-                            <th key={key} scope="col" aria-sort={sortKey === key ? (sortDirection === ASC ? "ascending" : "descending") : "none"}>
-                                <button type="button" onClick={() => handleSort(key)}>
-                                    {key} {getSortArrow(key)}
-                                </button>
-                                
-                            </th>
-                        ))}
-                    </tr>
-                </thead>
-                <tbody>
-                    {sortedRows && sortedRows.map((e:any) => (
-                        <tr>
-                            {columns && columns.map((key) => (
+  function getSortArrow(key: string) {
+    if (sortKey !== key) return <SortButton sortDirection={NONE}/>;
+    return sortDirection === ASC ? <SortButton sortDirection={ASC}/> : <SortButton sortDirection={DESC}/>;
+  }
 
-                                <td key={key}>
-                                    {e[key]}
-                                </td>
-                            ))}
-                        </tr>
-                    ))}
-                </tbody>
-            </Styled.Table>
-        }
-        </>
-    );
-}
+  return (
+    <>
+      {tableData && (
+        <Styled.Table>
+          <thead>
+            <tr>
+              {columns &&
+                columns.map((key) => (
+                  <th
+                    key={key}
+                    scope="col"
+                    aria-sort={
+                      sortKey === key
+                        ? sortDirection === ASC
+                          ? "ascending"
+                          : "descending"
+                        : "none"
+                    }
+                  >
+                    <Styled.HeaderButton type="button" onClick={() => handleSort(key)}>
+                      {key} 
+                      {getSortArrow(key)}
+                    </Styled.HeaderButton>
+                  </th>
+                ))}
+            </tr>
+          </thead>
+          <tbody>
+            {sortedRows &&
+              sortedRows.map((e: any) => (
+                <tr>
+                  {columns && columns.map((key) => <td key={key}>{e[key]}</td>)}
+                </tr>
+              ))}
+          </tbody>
+        </Styled.Table>
+      )}
+    </>
+  );
+};
 
 SortableTable.displayName = "Widgets.SortableTable";
 
 export default SortableTable;
-

--- a/packages/epo-widget-lib/src/widgets/SortableTable/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/SortableTable/styles.ts
@@ -2,9 +2,20 @@ import styled from "styled-components";
 
 export const Table = styled.table`
     border: 1px solid #000000;
+    font-size: medium;
     text-align: center;
     border-spacing: 0px;
     & > th, td, thead, thead > tr > th{
         border: 1px solid #000000;
     }
+
+    & > thead {
+        background-color: #009FA1;
+        font-size: large;
+    }
+`;
+
+export const HeaderButton = styled.button`
+    display: flex;
+    align-items: center;
 `;


### PR DESCRIPTION
Resolves #409 

## What this change does

Creates a new component for the sorting arrows. Updates `SortableTable` table header styling.

## Notes for reviewers

The ticket says to use a shade of gray for the header background, but with the arrows being gray & black the colors were too similar. I cycled through shades of gray, black and teal from the [Visual Identity lookbook](https://rubin.canto.com/g/RubinVisualIdentity/index?viewIndex=0) and settled on the colors you see below, but I welcome feedback on the color scheme.

<img width="969" height="255" alt="image" src="https://github.com/user-attachments/assets/22f2d644-16ef-4b45-bace-d73b090a3cd8" />

I took some liberties as well with the font sizing and very minor refactor of the header button (making it a Styled Component).

## Testing

Use Storybook for testing in isolation. Add the `SortableTable` widget to a page in a local instance of `investigations-client` to test in an investigation.