### PR TITLE
fix: update `isPlaying` state initialization so it is set to `false` if the widget `isDisplayOnly`

### DIFF
--- a/packages/epo-widget-lib/src/widgets/SourceSelector/MovingSourceSelector.tsx
+++ b/packages/epo-widget-lib/src/widgets/SourceSelector/MovingSourceSelector.tsx
@@ -64,7 +64,7 @@ const pointInsideCircle = (click: Point, center: Point, radius: number) => {
 const buildImageStack = (
   alerts: Array<Alert>,
   activeIndex: number,
-  isDisplayOnly: boolean
+  isDisplayOnly: boolean,
 ) => {
   if (isDisplayOnly) {
     return alerts[activeIndex] ? [alerts[activeIndex].image] : [];
@@ -85,142 +85,149 @@ const MovingSourceSelector: FunctionComponent<SourceSelectorProps> = ({
   isDisplayOnly = false,
   isLoading: isLoadingExternal,
   className,
-  movingSources = []
+  movingSources = [],
 }) => {
-    const [ currentIndex, setCurrentIndex ] = useState<number>(0);
-    const [isLoading, setLoading] = useState(true);
-    const [isPlaying, setIsPlaying] = useState(true);
-    const [message, setMessage] = useState<ReactNode>();
-    const [isMessageVisible, setMessageVisible] = useState(false);
-    const { t } = useTranslation();
-    const isPrepared = !isLoading && !isLoadingExternal;
+  const [currentIndex, setCurrentIndex] = useState<number>(0);
+  const [isLoading, setLoading] = useState(true);
+  const [isPlaying, setIsPlaying] = useState(isDisplayOnly ? false : true);
+  const [message, setMessage] = useState<ReactNode>();
+  const [isMessageVisible, setMessageVisible] = useState(false);
+  const { t } = useTranslation();
+  const isPrepared = !isLoading && !isLoadingExternal;
 
-    const clickIsInsideCircle = (
-        click: Point,
-        width: number,
-        height: number
-        ): string | undefined => {
-        if (movingSources) {
-            for(let movingSource of movingSources) {
-                const currentFrame = movingSource.sources[currentIndex];
-                let foundSource = pointInsideCircle(
-                    click,
-                    {
-                        x: toDecimalPercent(currentFrame.x) * width,
-                        y: toDecimalPercent(currentFrame.y) * height,
-                    },
-                    getRadius(movingSource.type, movingSource.radius) * width
-                )
-                if (foundSource) {
-                    return movingSource.id;
-                }
-            }
+  const clickIsInsideCircle = (
+    click: Point,
+    width: number,
+    height: number,
+  ): string | undefined => {
+    if (movingSources) {
+      for (let movingSource of movingSources) {
+        const currentFrame = movingSource.sources[currentIndex];
+        let foundSource = pointInsideCircle(
+          click,
+          {
+            x: toDecimalPercent(currentFrame.x) * width,
+            y: toDecimalPercent(currentFrame.y) * height,
+          },
+          getRadius(movingSource.type, movingSource.radius) * width,
+        );
+        if (foundSource) {
+          return movingSource.id;
         }
-    };
-
-    const notFound = () => {
-        setMessage(t("source_selector.messages.failure"));
-        setMessageVisible(true);
-    };
-
-    const handlePause = () => {
-        setIsPlaying(e => !e);
+      }
     }
-    const sourceFound = () => {
-        setMessage(
-        <>
-            <IconComposer icon="checkmark" />
-            {t("source_selector.messages.success")}
-        </>
-        );
-        setMessageVisible(true);
-    };
+  };
 
-    const handleClick: MouseEventHandler<HTMLDivElement> = ({
-        clientX: x,
-        clientY: htmlY,
-        target,
-    }) => {
-        if (!isPrepared || isDisplayOnly) return;
+  const notFound = () => {
+    setMessage(t("source_selector.messages.failure"));
+    setMessageVisible(true);
+  };
 
-        const {
-        tagName,
-        clientWidth: width,
-        clientHeight: height,
-        } = target as HTMLElement;
-
-        if (tagName.toLowerCase() !== "img") return;
-
-        const { left, top } = (target as HTMLElement).getBoundingClientRect();
-
-        /** remember that Y for SVG starts on the top side, click value needs to be flipped */
-        const clickedId = clickIsInsideCircle(
-            { x: x - left, y: height - htmlY + top },
-            width,
-            height
-        );
-
-        if (clickedId) {
-            const isAlreadySelected = selectedSource.includes(clickedId);
-
-            if (isAlreadySelected) return;
-            selectionCallback && selectionCallback(selectedSource.concat(clickedId));
-            sourceFound();
-        } else {
-            notFound();
-        }
-    };
-
-    const handleMessageChange = () => {
-        setMessageVisible(false);
-    };
-
-    const { day, hour } = calculateDiff(alerts, activeAlertIndex);
-
-    const images = buildImageStack(alerts, activeAlertIndex, isDisplayOnly);
-
-    const nextBlink = () => {
-        if (isPlaying) {
-          if(currentIndex > movingSources[0].sources.length - 2) {
-            setCurrentIndex(0)
-          } else {
-            setCurrentIndex(e => e + 1);
-          }
-        }
-    };
-    useInterval(nextBlink, 500);
-    
-    return (
-        <AspectRatio ratio={1} {...{ className }}>
-            {!isDisplayOnly && (
-                <Message
-                onMessageChangeCallback={handleMessageChange}
-                isVisible={isMessageVisible}
-                >
-                {message}
-                </Message>
-            )}
-        {movingSources && (
-            <Styled.BackgroundBlinker
-                images={images}
-                activeIndex={currentIndex}
-                blinkCallback={alertChangeCallback}
-                loadedCallback={() => setLoading(false)}
-                onClickCallback={handleClick}
-                extraControls={
-                alerts.length > 0 &&
-                !isDisplayOnly && <ElapsedTime {...{ day, hour }} />
-                }
-                interval={400}
-                pauseCallback={handlePause}
-                {...blinkConfig}
-            >
-                <MovingSourceMap {...{ width, height, isPlaying, currentIndex, movingSources, selectedSource }} /> 
-            </Styled.BackgroundBlinker>
-         )}
-        {!isPrepared && <Loader />}
-        </AspectRatio>
+  const handlePause = () => {
+    setIsPlaying((e) => !e);
+  };
+  const sourceFound = () => {
+    setMessage(
+      <>
+        <IconComposer icon='checkmark' />
+        {t("source_selector.messages.success")}
+      </>,
     );
+    setMessageVisible(true);
+  };
+
+  const handleClick: MouseEventHandler<HTMLDivElement> = ({
+    clientX: x,
+    clientY: htmlY,
+    target,
+  }) => {
+    if (!isPrepared || isDisplayOnly) return;
+
+    const {
+      tagName,
+      clientWidth: width,
+      clientHeight: height,
+    } = target as HTMLElement;
+
+    if (tagName.toLowerCase() !== "img") return;
+
+    const { left, top } = (target as HTMLElement).getBoundingClientRect();
+
+    /** remember that Y for SVG starts on the top side, click value needs to be flipped */
+    const clickedId = clickIsInsideCircle(
+      { x: x - left, y: height - htmlY + top },
+      width,
+      height,
+    );
+
+    if (clickedId) {
+      const isAlreadySelected = selectedSource.includes(clickedId);
+
+      if (isAlreadySelected) return;
+      selectionCallback && selectionCallback(selectedSource.concat(clickedId));
+      sourceFound();
+    } else {
+      notFound();
+    }
+  };
+
+  const handleMessageChange = () => {
+    setMessageVisible(false);
+  };
+
+  const { day, hour } = calculateDiff(alerts, activeAlertIndex);
+
+  const images = buildImageStack(alerts, activeAlertIndex, isDisplayOnly);
+
+  const nextBlink = () => {
+    if (isPlaying) {
+      if (currentIndex > movingSources[0].sources.length - 2) {
+        setCurrentIndex(0);
+      } else {
+        setCurrentIndex((e) => e + 1);
+      }
+    }
+  };
+  useInterval(nextBlink, 500);
+
+  return (
+    <AspectRatio ratio={1} {...{ className }}>
+      {!isDisplayOnly && (
+        <Message
+          onMessageChangeCallback={handleMessageChange}
+          isVisible={isMessageVisible}>
+          {message}
+        </Message>
+      )}
+      {movingSources && (
+        <Styled.BackgroundBlinker
+          images={images}
+          activeIndex={currentIndex}
+          blinkCallback={alertChangeCallback}
+          loadedCallback={() => setLoading(false)}
+          onClickCallback={handleClick}
+          extraControls={
+            alerts.length > 0 &&
+            !isDisplayOnly && <ElapsedTime {...{ day, hour }} />
+          }
+          interval={400}
+          pauseCallback={handlePause}
+          {...blinkConfig}>
+          <MovingSourceMap
+            {...{
+              width,
+              height,
+              isPlaying,
+              currentIndex,
+              movingSources,
+              selectedSource,
+            }}
+          />
+        </Styled.BackgroundBlinker>
+      )}
+      {!isPrepared && <Loader />}
+    </AspectRatio>
+  );
 };
 
 MovingSourceSelector.displayName = "Widgets.MovingSourceSelector";


### PR DESCRIPTION
## What this change does

Resolves #424 

This fixes the bug by conditionally initializing the `isPlaying` state based on the truthyness of the `isDisplayOnly` prop.

## Notes for reviewers

This file also got linted when I saved. The only actual edit is on line 92

## Testing

I confirmed this fix by using `yarn link` in the `investigations-client`, then adding the isDisplayOnly prop to a `MovingSourceSelector` widget. In my specific case this was done as part of fixing the [`MovingSourceSelector` on the review page bug](https://github.com/lsst-epo/investigations-client/issues/416).