### PR TITLE
fix: correct layout and display issues in OrbitalSim small formats

### DIFF
--- a/packages/epo-widget-lib/public/localeStrings/es/epo-widget-lib.json
+++ b/packages/epo-widget-lib/public/localeStrings/es/epo-widget-lib.json
@@ -78,7 +78,7 @@
   },
   "blinker": {
     "controls": {
-      "backward": "Hacia Atrás",
+      "backward": "Hacia atrás",
       "forward": "Adelantar",
       "pause": "Pausar",
       "play": "Reproducir",

--- a/packages/epo-widget-lib/public/localeStrings/fr/epo-widget-lib.json
+++ b/packages/epo-widget-lib/public/localeStrings/fr/epo-widget-lib.json
@@ -1,7 +1,7 @@
 {
   "blinker": {
     "controls": {
-      "backward": "Revenir en arrière",
+      "backward": "Reculer",
       "forward": "Avancer",
       "play": "Lecture",
       "pause": "Pause"

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Controls/PlaybackSpeed.jsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Controls/PlaybackSpeed.jsx
@@ -68,7 +68,7 @@ function PlaybackSpeed({
 
   return (
     <>
-      <Styled.PlaybackContainer>
+      <Styled.PlaybackSpeedContainer>
         <Styled.PlaybackSpeedSliderHeader>
           <Styled.PlaybackSpeedTitle>
             {t('orbital_sim.playback.time_step')}
@@ -122,7 +122,7 @@ function PlaybackSpeed({
             </Styled.ElapsedTimeBlock>
           </Styled.ElapsedTimeInner>
         </Styled.ElapsedTimeContainer>
-      </Styled.PlaybackContainer>
+      </Styled.PlaybackSpeedContainer>
     </>
   );
 }

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Controls/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Controls/styles.ts
@@ -1,7 +1,7 @@
 "use client";
 import styled from "styled-components";
 
-export const PlaybackContainer = styled.div`
+export const PlaybackSpeedContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   grid-template-rows: repeat(5, 1fr);
@@ -12,6 +12,10 @@ export const PlaybackContainer = styled.div`
   right: 20px;
   top: 10px;
   height: 95%;
+  
+  @container orbital-sim-context (width < 650px) {
+    height: 85%;
+  }
 `;
 
 export const PlaybackControlsContainer = styled.div`

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/styles.ts
@@ -43,7 +43,7 @@ export const SlideoutPanel = styled.div`
   gap: 1em;
   padding: 1em;
   font-size: 0.75rem;
-  width: '50ch';
+  width: 50ch;
 
   & > * + * {
     margin-block-start: 1em;

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/styles.ts
@@ -45,6 +45,8 @@ export const OrbitalSimWrapper = styled.div`
     min-height: 500px;
     background-color: #000000;
     color-adjust: exact;
+    container-type: size;
+    container-name: orbital-sim-context;
 `;
 
 export const CanvasWrapper = styled(Canvas)`
@@ -73,6 +75,7 @@ export const SwappableOrbitsContainer = styled.aside`
   z-index: 10;
   background-color: #fff;
   width: 10%;
+  min-width: fit-content;
   height: 100%;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What this change does

Resolves #429 

- Replaces the blinker "Rewind" text with "Backward".
- Prevents the PlaybackSpeed container from overlapping playback controls in small formats via a container query on OrbitalSimWrapper.
- Fixes invalid CSS syntax that was squishing the slideout.
- Stops text from overflowing swappable orbits buttons in small OrbitalSim formats.

## Notes

Translations are still broken locally so the "After" screenshots look a little rough but they should demonstrate the fixes adequately enough.

## Testing

I tested this in my local instance of `investigations-client` via `yarn link` to the `epo-widget-lib` package and in the `epo-widget-lib` Storybook where possible. Some of the layout issues were difficult to replicate in the storybook so those were primarily tested in the `investigations-client`.

## Screenshots

### Issue: Speed and Playback controls are overlapping

#### Before:
<img width="617" height="642" alt="image" src="https://github.com/user-attachments/assets/6fe4ca1e-5fe4-4520-b42f-f0e36e8a82ed" />

#### After:
<img width="617" height="642" alt="image" src="https://github.com/user-attachments/assets/9b8ee212-c324-49a2-9e8e-7f6b263b9ee0" />


### Issue: Improve Orbital Details slide-out when used in a two-column layout

#### Before:
<img width="617" height="642" alt="image" src="https://github.com/user-attachments/assets/f2d18ef0-329d-4e62-9f9c-0e8422e2d8eb" />

#### After:
<img width="617" height="642" alt="image" src="https://github.com/user-attachments/assets/9d48194e-5625-4927-99d0-a4f72a81715e" />


### Issue: Text overflow issues when an OrbitalSim with swappable orbits is used in a two-column layout

#### Before:
<img width="617" height="642" alt="image" src="https://github.com/user-attachments/assets/66757e77-4364-4640-9574-b77c47cbf6ba" />

#### After:
<img width="617" height="642" alt="image" src="https://github.com/user-attachments/assets/39f0a28d-28c4-4480-bb5c-3bfba5bd0e9d" />

