### PR TITLE
refactor: improve orbital line visibility by increasing the line width

### DIFF
--- a/packages/epo-widget-lib/src/types/astro.d.ts
+++ b/packages/epo-widget-lib/src/types/astro.d.ts
@@ -1,5 +1,5 @@
 export type Band = "u" | "g" | "r" | "i" | "z" | "y";
-export type SourceType = "supernova" | "galaxy" | "galaxyFilter" | "observation | asteroid";
+export type SourceType = "supernova" | "galaxy" | "galaxyFilter" | "observation" | "asteroid";
 
 export interface Source {
   id: string;

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/Orbital.jsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/Orbital.jsx
@@ -2,7 +2,7 @@ import React, { useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import * as THREE from "three";
 import { useFrame } from '@react-three/fiber';
-import { Html } from "@react-three/drei";
+import { Html, Line } from "@react-three/drei";
 import {
   DAY_PER_VIZ_SEC,
   getMinorAxis,
@@ -77,7 +77,7 @@ const Orbital = ({
     getCurve(majAxis, minAxis, offsetCenter.x, offsetCenter.y)
   );
 
-  const [pathLine] = useState(() => getLineGeometry(path.getPoints(360)));
+  const [pathLine] = useState(path.getPoints(360));
   const posZero = getPosFromArcLength(0, path);
   const [point, setPoint] = useState({
     position: posZero,
@@ -190,16 +190,16 @@ const Orbital = ({
     <group rotation={rotation}>
       {/* Orbital Path */}
       <group rotation={[0, 0, peri ? degsToRads(peri + 90) : 0]}>
-        <line ref={mesh} geometry={pathLine}>
-          <lineBasicMaterial
-            attach="material"
+        <Line
+          ref={mesh}
+          points={pathLine}
+          linewidth={2}
             color={
               active
                 ? ORBITAL_COLORS.asteroid.orbitHighlight
                 : orbitColor || ORBITAL_COLORS.asteroid.orbitColor
             }
-          />
-        </line>
+         />
         {/* Orbital Object */}
         <mesh
           position={point.position}


### PR DESCRIPTION
## What this change does

Resolves #431 

This PR replaces the three.js `lineBasicMaterial` primitive with react-three/drei `Line` component as the primitive does not support `linewidth` in our implementation.

It also fixes a typo in the SourceType type definition.

See:
https://threejs.org/docs/#LineBasicMaterial
https://drei.docs.pmnd.rs/shapes/line

## Notes for reviewers

The width change was approved by Ardis in her feedback document

## Testing

I tested the change in Storybook and my localhost investigations-client instance across all versions of the `OrbitalSim` implemented in the HazAst investigation.

## Screenshots (optional)

### Before:
<img width="586" height="687" alt="image" src="https://github.com/user-attachments/assets/3f093566-bcd9-4f40-bb5e-d6030dfdbb52" />


### After:
<img width="586" height="687" alt="image" src="https://github.com/user-attachments/assets/719337b3-d0f4-4812-bffe-b0b8fde08487" />
