### PR TITLE
fix: correct bug in `HorizontalSliderContainer` where `isVertical` was always being passed as `true`

### DIFF
--- a/packages/epo-react-lib/package.json
+++ b/packages/epo-react-lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rubin-epo/epo-react-lib",
   "description": "Rubin Observatory Education & Public Outreach team React UI library.",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "Rubin EPO",
   "license": "MIT",
   "homepage": "https://lsst-epo.github.io/epo-react-lib",

--- a/packages/epo-react-lib/src/molecules/HorizontalSlider/index.tsx
+++ b/packages/epo-react-lib/src/molecules/HorizontalSlider/index.tsx
@@ -98,7 +98,7 @@ const HorizontalSlider: FunctionComponent<HorizontalSliderProps> = ({
 
   return (
     <Styled.HorizontalSliderContainer
-      isVertical
+      isVertical={isVertical}
       style={{
         "--color-background-track": getValidColor(color),
       }}

--- a/packages/epo-react-lib/src/molecules/HorizontalSlider/styles.ts
+++ b/packages/epo-react-lib/src/molecules/HorizontalSlider/styles.ts
@@ -9,12 +9,7 @@ export const HorizontalSliderContainer = styled.div<{ isVertical?: boolean }>`
   flex-flow: column nowrap;
   padding-block-end: var(--size-padding-slide-block-end, var(--size-spacing-s));
 
-  ${({ isVertical }) =>
-    isVertical &&
-    css`
-      // height: 100%; // take up the full height of the canvas or orbitalsim container
-      height: 35vh;
-    `}
+  ${({ isVertical }) => isVertical && css`height: 35vh;`}
 
   &[data-theme="dark"] {
     --color-background-thumb: var(--white, #fff);


### PR DESCRIPTION
## What this change does

Resolves #428 

This PR fixes a bug where `isVertical` was always passed as `true` to the `HorizontalSliderContainer` component. This is because it was not being set to any value. Being added as a prop to the component without a value assignment resulted in it always being `true` when evaluated in the `HorizontalSliderContainer` component.

## Notes for reviewers

It's likely that this never caused an issue because the prop wasn't utilized until the Hazardous Asteroid investigation migration.

## Testing

This fix is made in the `epo-react-lib` package but is best tested in the `epo-widget-lib` Storybook and `investigation-client`. Storybook is probably sufficient, but I tested it in both.

To test in Storybook:

1. In the `epo-react-lib` package run `yarn build`
2. In the `epo-widget-lib` package run `yarn link "@rubin-epo/epo-react-lib"`
3. In the `epo-widget-lib` package run `yarn storybook`
4. Review any of the affected widgets listed in the original issue (`ColorTool` and `IsochronePlot` are good choices)

To test `investigations-client`
1. In the `epo-react-lib` package run `yarn build`
2. In the `epo-widget-lib` package run `yarn link "@rubin-epo/epo-react-lib"`
3. In the `epo-widget-lib` package run `yarn build`
4. In the `investigations-client` package run `yarn link "@rubin-epo/epo-widget-lib"`
5. Navigate to the pages in the investigations that utilize those widgets

## Screenshots (optional)

### Before:
<img width="960" height="574" alt="image" src="https://github.com/user-attachments/assets/0a9367bb-6636-4074-842b-7f3c88edd68f" />

### After:
<img width="960" height="574" alt="image" src="https://github.com/user-attachments/assets/9f6d2d9e-e441-4f14-bd99-c76c4b10affc" />
