### PR TITLE
fix: resized orbital labels for fit-to-content

### DIFF
--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/Orbital.jsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/Orbital.jsx
@@ -207,16 +207,12 @@ const Orbital = ({
         >
             {(type === "planet" || type === "neo" || active) && (
             <Html>
-              <Styled.Label>
-                <button
-                  type="button"
-                  style={{
+              <Styled.Label
+                style={{
                     fontSize: getLabelSize(zoomMod, defaultZoom),
                   }}
-                  onClick={() => selectionCallback(data, "neo")}
-                >
+              >
                   {translationKey ? t(translationKey) : name || pd}
-                </button>
               </Styled.Label>
             </Html>
           )}

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/styles.ts
@@ -12,7 +12,7 @@ export const SlideoutWrapper = styled(SlideoutInfoCard)`
 `;
 
 export const Label = styled.div`
-  padding: 2px 4px;
+  padding: 0px 4px;
   margin-top: 4px;
   font-weight: var(--medium);
   color: var(--black);

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Sun.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Sun.tsx
@@ -19,14 +19,12 @@ const Sun: FC<SunPropTypes> = ({ defaultZoom, zoomLevel }) => {
         color={ORBITAL_COLORS.sun.objectColor}
       />
       <Html>
-        <Styled.SunLabel>
-          <span
+        <Styled.SunLabel
           style={{
             fontSize: getLabelSize(zoomLevel, defaultZoom),
           }}
-          >
+        >
           {t("orbital_sim.astronomy.orbital_bodies.sun")}
-          </span>
         </Styled.SunLabel>
       </Html>
     </mesh>

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/orbitalUtilities.js
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/orbitalUtilities.js
@@ -266,7 +266,7 @@ export const convert2dTo3d = (vector2D, orbitData) => {
 };
 
 export const getLabelSize = (zoomLevel, defaultZoom) => {
-  const minSize = 4;
+  const minSize = 12;
   const maxSize = 15;
   const scaledLabelSize = maxSize * (zoomLevel / defaultZoom);
 

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/styles.ts
@@ -55,7 +55,7 @@ export const CanvasWrapper = styled(Canvas)`
 `;
 
 export const SunLabel = styled.div`
-  padding: 2px 4px;
+  padding: 0px 4px;
   margin-top: 4px;
   font-weight: var(--medium);
   color: var(--black);


### PR DESCRIPTION
Previously, the orbital labels were forced into an awkward square aspect ratio while zoomed in, and when zooming out only the horizontal dimension would shrink. This fix sets the label's height to the text size and also increases the minimum possible `font-size`.