### PR TITLE
chore: update semantic release

### DIFF
--- a/.github/workflows/dev-pull-request.yml
+++ b/.github/workflows/dev-pull-request.yml
@@ -2,8 +2,8 @@ name: Run Jest unit tests
 on:
   pull_request:
     branches: 
-      - develop
-      - develop-v3
+      - develop-react-v19
+      - develop-react-v18
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main-push.yaml
+++ b/.github/workflows/main-push.yaml
@@ -2,10 +2,10 @@
 name: Build and Publish Storybook to GitHub Pages
 
 on:
-  # Event for the workflow to run on
   push:
     branches:
-      - "main" # Replace with the branch you want to deploy from
+      - release-react-v19
+      - release-react-v18
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ A lowest level building blocks library containing core styling and low level com
 
 Scientific discovery widgets developed for education investigations.
 
+## Releases
+
+[See the release documentation.](RELEASE.md)
+
 ## Workspaces
 
 Each package is its own workspace. [Yarn workspaces](https://classic.yarnpkg.com/lang/en/docs/workspaces/) give each package it's own workspace area while sharing common dependencies through a top-level `node_modules` folder. An advantage of this setup is that if one package is installed by another, it will symlink the package instead of installing from the online source.
@@ -26,21 +30,6 @@ For example:
 /packages/epo-react-lib
 /packages/epo-widget-lib
 ```
-
-In the above example if you made changes to `epo-react-lib` and want to reference them locally in `epo-widget-lib` you would modify the dependency version as such:
-
-`/packages/epo-widget-lib/package.json`:
-```
-...
-dependencies: {
-   "@rubin-epo/epo-react-lib": "0.0.0-development",
-}
-...
-```
-
-The key part here is `0.0.0-development` which is the value of the `version` property in `packages/epo-react-lib/package.json`.
-
-After you update the `package.json`, run `yarn install` in the root-level of this project for Yarn workspaces to resolve the local dependencies. **Just be mindful not to check this change in!**
 
 ### Local Development in Application Repos
 
@@ -65,3 +54,5 @@ yarn
 ```
 
 You can confirm that the installation is symlinked by then going into `./node_modules/@rubin-epo/` and running `ls -l` to see the symlink
+
+The same can be done for linking a local built version of `@rubin-epo/epo-react-lib` in `@rubin-epo/epo-widget-lib`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,15 @@ Several tokens or moving parts may be out of place at any given point in time, p
 
 This monorepo makes use of the [semantic-release](https://www.npmjs.com/package/semantic-release) NPM package. This package runs automatically during the release scripts and if there are commits in any individual repo - which will trigger a new release for that package - and what the prefix on the conventional commits are (`fix`, `feat`) to determine the semantic version.
 
-If all goes right you won't need to manually create the tagged release in Github upon merging into the `main` branch.
+There are two sets of release and development branches branches:
+
+1.a `release-react-v19` - the "main" and primary release branch, as the name indicates this is for all React v19-compatible code
+
+1.b `develop-react-v19` - the development branch for React v19 code
+
+2.a `release-react-v18` - the maintenance branch for supporting React v18 components and widgets
+
+2.b `develop-react-v18` - the development branch for React v18 code
 
 ## Yarn Workspaces
 
@@ -21,7 +29,7 @@ The Github repo has two sets of environment variables, the one related to releas
 
 ## Github Workflows
 
-All PRs should from from `feature branch` -> `develop` -> `main`. Upon merging into main two workflows are launched:
+All PRs should from from `feature branch` -> `develop-react-v19` || `develop-react-v18` -> `release-react-v19` || `release-react-v18`. Upon merging into main two workflows are launched:
 
 1. One related to building and publishing to Storybook
 2. Another for running the above workflow in the `Yarn Workspaces` section above, which will create the tagged release in Github and publish the new packages to npmjs.org
@@ -30,4 +38,4 @@ The `Release packages` logs are pretty straightforward, if the action fails it u
 
 ## Order of Operations
 
-At times it will be necessary to make a change to `epo-react-lib`, and then use that change in `epo-widget-lib` or one of the other packes. The safest way to ensure this goes smoothly is to make your changes to `epo-react-lib` first then merge all the way to `main` so a new version of the `epo-react-lib` package gets released. You can then reference this new version of `epo-react-lib` in the `epo-widget-lib` package's `package.json` for your next development update.
+At times it will be necessary to make a change to `epo-react-lib`, and then use that change in `epo-widget-lib` or one of the other packes. The safest way to ensure this goes smoothly is to make your changes to `epo-react-lib` first then merge all the way to the target release branch so a new version of the `epo-react-lib` package gets released. You can then reference this new version of `epo-react-lib` in the `epo-widget-lib` package's `package.json` for your next development update.

--- a/packages/epo-react-lib/release.config.mjs
+++ b/packages/epo-react-lib/release.config.mjs
@@ -2,7 +2,11 @@
  * @type {import('semantic-release').GlobalConfig}
  */
 const release = {
-  branches: ["main"],
+  tagFormat: '@rubin-epo/epo-react-lib-v${version}',
+  branches: [
+    "release-react-v19",
+    { name: "release-react-v18", range: "2.x", channel: "react-18" }
+  ],
   plugins: [
     [
       "@semantic-release/commit-analyzer",

--- a/packages/epo-widget-lib/release.config.mjs
+++ b/packages/epo-widget-lib/release.config.mjs
@@ -2,7 +2,11 @@
  * @type {import('semantic-release').GlobalConfig}
  */
 const release = {
-  branches: ["main"],
+  tagFormat: '@rubin-epo/epo-widget-lib-v${version}',
+  branches: [
+    "release-react-v19",
+    { name: "release-react-v18", range: "1.x", channel: "react-18" }
+  ],
   plugins: [
     [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
This is long overdue. Prior to starting the Hazardous Asteroids legacy port we upgraded the React and Next.js version of `investigations-client` to v19 and v15, respectively. This required us to create dedicated React v19 branches in this repo so they could be compatible with React v19. Largely, the components and widgets _were_ compatible, but there were enough breaking changes that were not backwards compatible. So while we started the Hazardous Asteroids port we had to manually publish NPM packages because `main` was locked into React v18. This was an unfortunately necessary workflow to unblock us and we successfully hit the Hazardous Asteroids port target dates (yay).

Now the dev group has some breathing room, I have finally been able to return to fleshing out a more complex release/publish workflow with `semantic-release` so we have a React v18 maintenance release branch and a React v19 default release branch. The documentation in `RELEASE.md` outlines the necessary steps to trigger a release in the primary or maintenance release branches.

When the time comes to update to React v20, we can create a new branch called `release-react-v20` and make it the default branch, and update the `release.config.mjs` files to set `release-react-v19` to a maintenance branch.