### PR TITLE
feat: update orbitalSim and provider to receive the defaultZoom value as a prop

### DIFF
--- a/packages/epo-widget-lib/src/mock-data/OrbitalSim/index.ts
+++ b/packages/epo-widget-lib/src/mock-data/OrbitalSim/index.ts
@@ -7,7 +7,6 @@ export const SwappableOrbitsData = {
             atira,
             amor
         ],
-        defaultZoom: 3
     },
     swappableOrbits: true
 }
@@ -58,7 +57,6 @@ export const PrimaryData = {
   selectionCallback: () => {},
   paused: true,
   pov: "top",
-  defaultZoom: 3,
   potentialOrbits: null,
   observations: null,
   noDetails: true,
@@ -18090,7 +18088,6 @@ export const PotentialOrbitsData = {
     selectionCallback: () => {},
     paused: null,
     pov: null,
-    defaultZoom: 3,
     potentialOrbits: true,
     observations: [
         {
@@ -18250,7 +18247,6 @@ export const ObjectDetailsData = {
     selectionCallback: () => {},
     paused: null,
     pov: null,
-    defaultZoom: 3,
     potentialOrbits: null,
     observations: null,
     detailsSet: "hazardous-asteroids",

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/OrbitalSimContext.types.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/OrbitalSimContext.types.ts
@@ -3,6 +3,7 @@ import { ReactNode } from "react";
 export interface OrbitalSimProviderProps {
     children: ReactNode,
     orbitData: Orbits,
+    defaultZoom: number,
     showDetailsTable?: boolean,
     allowOrbitRotation?: boolean,
     showTimeControls?: boolean,
@@ -14,6 +15,7 @@ export interface OrbitalSimProviderProps {
 
 export type OrbitalSimContextValues = {
   orbits: Orbits;
+  defaultZoom: number;
   showDetailsTable?: boolean;
   allowOrbitRotation?: boolean;
   showTimeControls?: boolean;
@@ -56,7 +58,6 @@ export type Orbits = {
     observations: Observation[],
     paused: boolean,
     pov: string | null,
-    defaultZoom: number | null,
     potentialOrbits: boolean,
     noDetails: boolean,
     refObjs: string[] | null,

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
@@ -44,6 +44,7 @@ export function useOrbitalSimContext() {
 export function OrbitalSimProvider({ 
     children,
     orbitData,
+    defaultZoom,
     showDetailsTable=false,
     allowOrbitRotation=false,
     showTimeControls=false,
@@ -58,7 +59,6 @@ export function OrbitalSimProvider({
         observations: [],
         paused: false,
         pov: null,
-        defaultZoom: null,
         potentialOrbits: false,
         noDetails: false,
         refObjs: null,
@@ -95,6 +95,7 @@ export function OrbitalSimProvider({
 
     const values: OrbitalSimContextValues = useMemo(() => ({
         orbits,
+        defaultZoom,
         showDetailsTable,
         allowOrbitRotation,
         showTimeControls,   
@@ -106,6 +107,7 @@ export function OrbitalSimProvider({
         selectedNeoIndex
   }),[
     orbits,
+    defaultZoom,
     showDetailsTable,
     allowOrbitRotation,
     showTimeControls, 

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.stories.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.stories.tsx
@@ -8,6 +8,14 @@ import { PrimaryData, PotentialOrbitsData, ObjectDetailsData, SwappableOrbitsDat
 const meta: Meta<typeof OrbitalSim> = {
   component: OrbitalSim,
   parameters: { r3f: true },
+  args: {
+    defaultZoom: 0.5,
+  },
+  argTypes: {
+    defaultZoom: {
+      control: { type: 'number', step: 0.01 },
+    },
+  },
 };
 export default meta;
 
@@ -24,6 +32,7 @@ const Template: StoryFn<typeof OrbitalSim> = (args:any ) => {
       {args.observations && <SelectionList sources={ selectedAnswer ? [{ type: "observation", id: selectedAnswer}] : [] } onRemoveCallback={ resetSelectedAnswer }/>}
       <OrbitalSimProvider 
         orbitData={args.orbits}
+        defaultZoom={args.defaultZoom}
         selectedAnswer={selectedAnswer}
         updateSelectedAnswer={setSelectedAnswer}
         showDetailsTable={args.showDetailsTable}

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/OrbitalSim.tsx
@@ -11,14 +11,12 @@ import { useOrbitalSimContext } from "./Context/index.js";
 import { Neo } from "./Context/OrbitalSimContext.types.js"
  
 function OrbitalSim() {
-  const { orbits, showDetailsTable, allowOrbitRotation, showTimeControls, swappableOrbits, selectedNeoIndex }= useOrbitalSimContext();
+  const { orbits, defaultZoom, showDetailsTable, allowOrbitRotation, showTimeControls, swappableOrbits, selectedNeoIndex }= useOrbitalSimContext();
   const { 
     paused,
     pov,
-    defaultZoom,
     potentialOrbits,
    } = orbits;
-
   const speeds = { min: 0.00001157, max: 365.25, initial: 11.574, step: 1 };
   const [playing, setPlaying] = useState(!paused);
   const [stepDirection, setStepDirection] = useState(1);
@@ -26,7 +24,7 @@ function OrbitalSim() {
   const [dayPerVizSec, setDayPerVizSec] = useState(paused ? 0 : speeds.initial);
   const [elapsedTime, setElapsedTime] = useState(0);
   const [reset, setReset] = useState(0);
-  const [zoomLevel, setZoomLevel] = useState(1);
+  const [zoomLevel, setZoomLevel] = useState(defaultZoom);
   const [currentSwappableOrbit, setCurrentSwappableOrbit] = useState({ neos: [ { Principal_desig: "" }]});
 
   useEffect(() => {


### PR DESCRIPTION
## What this change does

Resolves #456 

This PR updates the `OrbitalSimProvider` and `OrbitalSim` component to handle receiving the `defaultZoom` as a prop. It also corrects a hardcoded default zoom value that has been overriding what was set in the datasets.

Additionally it updates the Storybook configuration for this widget to allow setting a default zoom value.

I also snuck in the prop Type fix from issue #445.

## Notes

### Regarding where the `defaultZoom` fallback value is set

I decided to make the `defaultZoom` a required prop that only accepts a `number` in the types definition in `packages/epo-widget-lib/src/widgets/OrbitalSim/Context/OrbitalSimContext.types.ts`. While allowing the prop to be `null` or `undefined` and setting a fallback value in the context provider is a valid approach that I considered, I ultimately felt that the fallback value should be handled in the client. This keeps the widget itself as agnostic as possible and allows the implementor to determine an use a default value that is appropriate for their use case instead of a value we arbitrarily set right now.

## Testing

Basic testing can performed in the Storybook but yarn linking this package into the `investigations-client` and testing in the HazAst investigation is best.

Confirm the following testing is complete:

- [x] Testing the package builds successfully
- [x] Testing the component in isolation in its own story(ies)
- [x] Testing the component in any stories for widgets or other components that use it
- [x] Testing the component in the target client, if possible/feasible
- [x] Testing the target client builds successfully