### PR TITLE
fix: correct the type definitions for the orbital sim context provider

### DIFF
--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/OrbitalSimContext.types.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/OrbitalSimContext.types.ts
@@ -7,8 +7,8 @@ export interface OrbitalSimProviderProps {
     showDetailsTable?: boolean,
     allowOrbitRotation?: boolean,
     showTimeControls?: boolean,
-    selectedAnswer: string | null,
-    updateSelectedAnswer: (newSelectedAnswer: string | null) => void,
+    selectedAnswer?: string | null,
+    updateSelectedAnswer?: (newSelectedAnswer: string | null) => void,
     swappableOrbits?: boolean,
     selectedNeoIndex?: number,
 }
@@ -22,7 +22,7 @@ export type OrbitalSimContextValues = {
   setOrbits: React.Dispatch<React.SetStateAction<Orbits>>;
   observations: Observation[];
   updateActiveObservation: (activeId: string) => void;
-  selectedAnswer: string | null;
+  selectedAnswer?: string | null;
   swappableOrbits: boolean;
   selectedNeoIndex?: number;
 };

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Context/index.tsx
@@ -88,8 +88,10 @@ export function OrbitalSimProvider({
             let newObs = observations.map(e => (e.id == activeId) ? {...e, isActive: true} : {...e, isActive: false});
             setObservations(newObs);
             
-            const activeObservation = observations.find(e => (e.id === activeId));
-            updateSelectedAnswer(activeObservation?.label || null);
+            if (updateSelectedAnswer) {
+                const activeObservation = observations.find(e => (e.id === activeId));
+                updateSelectedAnswer(activeObservation?.label || null);
+            }
         }
     }
 


### PR DESCRIPTION
## What this change does

Resolves #445

This PR corrects the type definitions for the orbital sim context provider by making the ones that are only needed for use in the question version of the widget optional.

## Notes for reviewers

This is a level 3 review

- 0 = "This is an FYI heads up to get your eyes on this"
- 1 = "I barely need review on this"
- 5 = "Please make sure there are no obvious errors and that you believe it does what it says it does"
- 10 = "I think it works, I can explain how, but only over screenshare"

## Testing

To verify this works:
1. `yarn link` the `epo-widget-lib` package into the `investigations-client`
2. Verify Typescript isn't flagging the prop errors on `OrbitalSimProvider` in `components/content-blocks/OrbitalSim/OrbitalSimWidget.tsx` or `components/questions/Widget/OrbitalSim/index.tsx`
3. Verify that question and non-question orbital sims still work correctly.

Confirm the following testing is complete:

- [x] Testing the package builds successfully
- [x] Testing the component in isolation in its own story(ies)
- [x] Testing the component in any stories for widgets or other components that use it
- [x] Testing the component in the target client, if possible/feasible
- [x] Testing the target client builds successfully