### PR TITLE
fix: prevent OrbitalSim playback UI from overlapping in small views by adding a height based container query

### DIFF
--- a/packages/epo-widget-lib/package.json
+++ b/packages/epo-widget-lib/package.json
@@ -102,7 +102,7 @@
   "dependencies": {
     "@react-three/drei": "^10.7.6",
     "@react-three/fiber": "9",
-    "@rubin-epo/epo-react-lib": "3.0.3",
+    "@rubin-epo/epo-react-lib": "^3.0.4",
     "context-filter-polyfill": "^0.3.6",
     "d3-array": "^3.2.4",
     "d3-geo": "^3.1.1",

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Controls/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Controls/styles.ts
@@ -16,6 +16,10 @@ export const PlaybackSpeedContainer = styled.div`
   @container orbital-sim-context (width < 650px) {
     height: 85%;
   }
+
+  @container orbital-sim-context (height < 575px) {
+    height: 75%;
+  }
 `;
 
 export const PlaybackControlsContainer = styled.div`

--- a/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/styles.ts
+++ b/packages/epo-widget-lib/src/widgets/OrbitalSim/Orbitals/styles.ts
@@ -4,11 +4,7 @@ import Button from "@rubin-epo/epo-react-lib/Button";
 import SlideoutInfoCard from "@rubin-epo/epo-react-lib/SlideoutInfoCard";
 
 export const SlideoutWrapper = styled(SlideoutInfoCard)`
-  position: absolute;
-
-  & > div:first-of-type {
-    display: none;
-  }
+  z-index: 10;
 `;
 
 export const Label = styled.div`

--- a/yarn.lock
+++ b/yarn.lock
@@ -3429,6 +3429,23 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
+"@rubin-epo/epo-react-lib@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@rubin-epo/epo-react-lib/-/epo-react-lib-3.0.4.tgz#65281789a0b4b311b167b46e4313285b723456d1"
+  integrity sha512-UCSRAUo3JJeQbQp1IxFE876GQEJ07alrrBuCj1MbuYplN3SwG69XdF19LwW/uC6C1i/x26byJNuAi4kndQyEgA==
+  dependencies:
+    "@castiron/style-mixins" "^1.0.6"
+    "@headlessui/react" "^2.2.0"
+    flickity "^3.0.0"
+    focus-trap "^7.4.2"
+    lodash "^4.17.21"
+    react-icons "^5.5.0"
+    react-player "^2.14.1"
+    react-share "^5.2.2"
+    react-slider "^2.0.6"
+    styled-components "^6.1.16"
+    utopia-core "^1.6.0"
+
 "@rushstack/eslint-patch@^1.10.3":
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz#4f97581e114fc79f246cee3723a5c4edd3b62415"
@@ -4408,7 +4425,7 @@
   dependencies:
     postcss-preset-env "*"
 
-"@types/react-dom@19.2.3", "@types/react-dom@19.2.3`", "@types/react-dom@^18.0.0":
+"@types/react-dom@19.2.3", "@types/react-dom@^18.0.0":
   version "19.2.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-19.2.3.tgz#c1e305d15a52a3e508d54dca770d202cb63abf2c"
   integrity sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==
@@ -5972,7 +5989,14 @@ conventional-changelog-angular@^8.0.0:
   dependencies:
     compare-func "^2.0.0"
 
-conventional-changelog-conventionalcommits@8.0.0, conventional-changelog-conventionalcommits@^7.0.2, conventional-changelog-conventionalcommits@^8.0.0:
+conventional-changelog-conventionalcommits@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz#aa5da0f1b2543094889e8cf7616ebe1a8f5c70d5"
+  integrity sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==
+  dependencies:
+    compare-func "^2.0.0"
+
+conventional-changelog-conventionalcommits@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz#3fa2857c878701e7f0329db5a1257cb218f166fe"
   integrity sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==


### PR DESCRIPTION
## What this change does
Resolves #464 
Resolves #458

This fix prevents the OrbitalSim playback UI from overlapping in small views by adding a height based container query to handle these size situations.

This PR also fixes the issue of the Orbital Details slideout rendering above the investigations-client sites header and menu slideouts by overriding the default `z-index` set in the `epo-react-lib`'s `SlideoutInfoCard` component.

## Testing

This can be most easily tested in Storybook with the Potential Orbits or Orbital Details stories.
In the `investigations-client`, the OrbitalSim on the `/hazardous-asteroids/predicting-where-to-observe-next` page is the easiest to test with (and is where this issue was happening).

The `z-index` fix needs to be tested in the `investigations-client`. Open and Object Details slide out and verify that it is not rendered on top of either of the Settings or Table of contents slideouts or the main side `<header>`.

Confirm the following testing is complete:

- [x] Testing the package builds successfully
- [x] Testing the component in isolation in its own story(ies)
- [x] Testing the component in any stories for widgets or other components that use it
- [x] Testing the component in the target client, if possible/feasible
- [x] Testing the target client builds successfully

## Screenshots
### Before:
<img width="566" height="554" alt="image" src="https://github.com/user-attachments/assets/f083589e-cc6c-409d-b939-4c67483bb0c8" />

### After:
<img width="566" height="554" alt="image" src="https://github.com/user-attachments/assets/3b7340e7-9128-4919-b0f4-73eb7fbc11f2" />
