### PR TITLE
fix: add missing prop in `SlideoutInfoCard` preventing CSS application in `epo-widget-lib`

### DIFF
--- a/packages/epo-react-lib/src/atomic/SlideoutInfoCard/SlideoutInfoCard.tsx
+++ b/packages/epo-react-lib/src/atomic/SlideoutInfoCard/SlideoutInfoCard.tsx
@@ -14,10 +14,11 @@ const SlideoutInfoCard: FunctionComponent<SlideoutInfoCardProps> = ({
   isOpen = false, 
   slideFrom = "left", 
   children,
+  className,
 }) => {
 
   return (
-    <Styled.SlideoutInfoCard isOpen={isOpen} slideFrom={slideFrom}>
+    <Styled.SlideoutInfoCard isOpen={isOpen} slideFrom={slideFrom} className={className}>
       {children}
     </Styled.SlideoutInfoCard>
   );


### PR DESCRIPTION
## What this change does

Resolves #466 

This PR fixes a bug where the `SlideoutInfoCard` component in `epo-react-lib` was not destructuring and utilizing the `className` prop which was causing any CSS being set in the target implementation to not be applied (the 
`ObjectDetails` in the `epo-widget-lib` in this case).

## Notes

This PR is blocking PR #465 

## Testing

I'm not sure how this fix can be tested in isolation as I was only able to resolve it while working on the [z-index bug in the `epo-widget-lib`](https://github.com/lsst-epo/epo-react-lib/issues/458).

Confirm the following testing is complete:

- [x] Testing the package builds successfully
- [x] Testing the component in isolation in its own story(ies)
- [x] Testing the component in any stories for widgets or other components that use it
- [x] Testing the component in the target client, if possible/feasible
- [x] Testing the target client builds successfully